### PR TITLE
Fix 18401 future commit links

### DIFF
--- a/_posts/2020-04-01-#18401.md
+++ b/_posts/2020-04-01-#18401.md
@@ -78,7 +78,7 @@ This week, we'll review two (small) PRs:
 - Because of these changes, more data needs to be stored in the
   `PrecomputedTransactionData` object. This PR changes the way that the object
   is constructed and initialized so that a [future commit in PR
-  17977](https://github.com/bitcoin/bitcoin/pull/17977/commits/dd0622b8e2f8a324fdf73eb476f136ee556f3e68)
+  17977](https://github.com/bitcoin/bitcoin/pull/17977/commits/6dcc85e3347fe8a0c5e3e578176fd38fa093df39)
   can add that data to the object.
 
 ### PR 18422: Move single-sig checking EvalScript code to EvalChecksig
@@ -96,7 +96,7 @@ This week, we'll review two (small) PRs:
   `OP_CHECKSIGVERIFY` from the very large `EvalScript()` function.
 
 - A [future commit in PR
-  17977](https://github.com/bitcoin/bitcoin/pull/17977/commits/af411a6cbec12375627aff374874a7f24b7c07e9)
+  17977](https://github.com/bitcoin/bitcoin/pull/17977/commits/619105fb4bb51ef3eaeb61df755c121d3f902b7f)
   modifies this function to switch on which flags have been passed into the
   script interpreter in order to determine whether to do schnorr or ECDSA
   signature verification.


### PR DESCRIPTION
The commits referenced were outdated. I am pretty sure I got the right ones, but please check again, one of the commits referenced seems to have been split.