### PR TITLE
Minor changes to n18453

### DIFF
--- a/_posts/2020-04-08-#18453.md
+++ b/_posts/2020-04-08-#18453.md
@@ -51,7 +51,7 @@ entitled *"rpc: Deprecate getunconfirmedbalance and getwalletinfo balances"*.
 
 ### Bitcoin Core deprecation process
 
-#### Soft versus hard deprecation
+#### -deprecatedrpc and DEPRECATED comments
 
 - Officially, RPC API deprecations in Bitcoin Core now follow the process
   described in
@@ -63,18 +63,18 @@ entitled *"rpc: Deprecate getunconfirmedbalance and getwalletinfo balances"*.
 - Nevertheless, Bitcoin Core also has RPCs that contain "DEPRECATED" warnings in
 capital letters in the help documentation, but which are not actually
 deprecated. Why? Because they have not begun the `-deprecatedrpc` flag
-process. I'll refer to these as *soft deprecations*.
+process.
 
 - Other RPCs with "DEPRECATED" warnings are in the official deprecation
-  process. Let's call them *hard deprecations*.
+  process.
 
-- Here are two examples of PRs that launch the hard deprecation process:
+- Here are two examples of PRs that launch the deprecation process:
   - [PR 17578 "rpc: simplify getaddressinfo labels, deprecate previous
 behavior"](https://github.com/bitcoin/bitcoin/pull/17578)
   - [PR 17585 "rpc: deprecate getaddressinfo
 label"](https://github.com/bitcoin/bitcoin/pull/17585)
 
-#### When to hard deprecate, and when to remove?
+#### When to deprecate, and when to remove?
 
 - One way of thinking about this might be to distinguish between possibly minor
 deprecations, like removing an RPC input argument or result field, and removing
@@ -92,7 +92,7 @@ on it.
 
 This PR is an illustration of that. It originally began with just one commit to
 enable `-getinfo` to call `getbalances`, in order to no longer depend on the
-`getwalletinfo` balance response that was soft-deprecated a year earlier.
+`getwalletinfo` balance response that was marked as DEPRECATED a year earlier.
 
 Then, Bitcoin Core maintainer [laanwj](https://github.com/laanwj) proposed,
 while updating this code, [to add displaying the balance per
@@ -143,26 +143,13 @@ output.
 
 Many of the wallet RPCs are in
 [`src/wallet/rpcwallet.cpp`](https://github.com/bitcoin/bitcoin/blob/master/src/wallet/rpcwallet.cpp),
-including the ones we are interested in for this PR. Listed by line number, the
-RPCs in that file are:
-
-```code
-getnewaddress, getrawchangeaddress, setlabel, sendtoaddress,
-listaddressgroupings, signmessage, getreceivedbyaddress, getreceivedbylabel,
-getbalance, getunconfirmedbalance, sendmany, addmultisigaddress,
-listreceivedbyaddress, listreceivedbylabel, listsinceblock, gettransaction,
-abandontransaction, backupwallet, keypoolrefill, walletpassphrase,
-walletpassphrasechange, walletlock, encryptwallet, lockunspent, listlockunspent,
-settxfee, getbalances, getwalletinfo, listwalletdir, listwallets, loadwallet,
-setwalletflag, createwallet, unloadwallet, listunspent, fundrawtransaction,
-bumpfee, getaddressesbylabel, listlabels
-```
+including the ones we are interested in for this PR.
 
 #### Commits
 
 - In the first
 [commit](https://github.com/bitcoin/bitcoin/pull/18453/commits/ea139c6af3bcda55fa7d50d20c731e71940271d0),
-`-getinfo` is changed to replace depending on the soft-deprecated
+`-getinfo` is changed to replace using
 `getwalletinfo.balance` with using `getbalances.ismine.trusted`.
 
 - In the second


### PR DESCRIPTION
- Remove hard/soft terminology.
- Remove listing of wallet RPCs (attendees can look these up easily)