### PR TITLE
Exclude non-site files from build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,16 @@ twitter:
   card: summary
   username: BitcoinCorePRs
 
+# Exclude from processing
+exclude:
+   - CONTRIBUTING.md
+   - Gemfile
+   - Gemfile.lock
+   - Makefile
+   - README.md
+   - Rakefile
+   - test/
+
 defaults:
   - scope:
       path: ""  ## all pages


### PR DESCRIPTION
There are some files that get included in the site build that shouldn't be, eg go to https://bitcoincore.reviews/Makefile. Exclude them.