### PR TITLE
n18468  component tag fix and notes tidy-ups

### DIFF
--- a/_posts/2020-06-24-#18468.md
+++ b/_posts/2020-06-24-#18468.md
@@ -4,7 +4,7 @@ date: 2020-06-24
 title: "Span improvements"
 pr: 18468
 authors: [sipa]
-components: ["refactor"]
+components: ["refactoring"]
 host: sipa
 status: past
 commit: 26acc8dd

--- a/_posts/2020-06-24-#18468.md
+++ b/_posts/2020-06-24-#18468.md
@@ -17,11 +17,11 @@ the changes in that commit as well, as they functionally belong together.
 
 ## Notes
 
-- Today's PR is the recently-merged [#18468: Span Improvements](https://github.com/bitcoin/bitcoin/pull/18468).
-  It brings our `Span` type closer to the functionality of C++20's proposed [`std::span`](https://en.cppreference.com/w/cpp/container/span), and
+- Today's PR is the recently merged [#18468: Span Improvements](https://github.com/bitcoin/bitcoin/pull/18468).
+  It brings our `Span` type closer to the functionality of C++20's proposed [`std::span`](https://en.cppreference.com/w/cpp/container/span) and
   then demonstrates some of its uses by simplifying code that uses it in various places.
 
-- A `Span` can be thought of as a pair of a pointer to some data type together with a length,
+- A `Span` can be thought of as a pair composed of a pointer to a data type together with a length,
   identifying a range of contiguous elements in memory. In many ways it acts like a vector,
   but it doesn't own any data --- which means no copying of the actual data is involved. It is
   an extremely lightweight object, but it does come with a cost: higher-level code is responsible
@@ -29,17 +29,17 @@ the changes in that commit as well, as they functionally belong together.
 
 - `std::span` is a new data type that will likely be part of the upcoming C++20 standard
   (see the cppreference.com page on [std::span](https://en.cppreference.com/w/cpp/container/span)).
-  While Bitcoin Core won't switch to that standard any time soon (we're currently on C++11, and will
+  While Bitcoin Core won't switch to that standard any time soon (we're currently on C++11 and will
   be transitioning to C++17 over the next 2 releases), it is a remarkably useful and simple
-  abstraction, which is why we have our own backported version that is C++11 compatible.
+  abstraction, which is why we have our own backported version that is compatible with C++11.
   `Span` isn't quite as powerful as `std::span`, but today's PR brings it a lot closer.
 
 - The gist of the changes is introducing implicit construction of `Span` objects from range-like
   objects ([arrays](https://en.cppreference.com/w/cpp/language/array),
-  [`std::array`s](https://en.cppreference.com/w/cpp/container/array),
-  [`std::vector`s](https://en.cppreference.com/w/cpp/container/vector),
-  [`prevector`s](https://github.com/bitcoin/bitcoin/blob/f3d776b59380ad31e8b3a2948364c7690eebe05d/src/prevector.h),
-  [`std::string`s](https://en.cppreference.com/w/cpp/string/basic_string), ...), and
+  [`std::array`](https://en.cppreference.com/w/cpp/container/array),
+  [`std::vector`](https://en.cppreference.com/w/cpp/container/vector),
+  [`prevector`](https://github.com/bitcoin/bitcoin/blob/f3d776b59380ad31e8b3a2948364c7690eebe05d/src/prevector.h),
+  [`std::string`](https://en.cppreference.com/w/cpp/string/basic_string), etc.) and
   automatic conversion between `Span` of compatible member types. Implicit construction and
   conversion is a powerful but dangerous C++ feature that should be used cautiously. Most of
   the complexity in the code changes is in making sure these operations cannot be used in
@@ -57,8 +57,8 @@ the changes in that commit as well, as they functionally belong together.
 ## Questions
 
 1. Did you review the PR? [Concept ACK, approach ACK, tested ACK, or
-   NACK?](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#peer-review)
-   (You're always encouraged to put your PR review on GitHub, even after it has been merged)
+   NACK](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#peer-review)?
+   (You're always encouraged to put your PR review on GitHub, even after the PR has been merged.)
 
 2. Do you think `Span` is a useful abstraction? Can you think of more places where it could
    be used to simplify existing code?


### PR DESCRIPTION
Noticed the component tag was creating a second `refactor` component type in https://bitcoincore.reviews/meetings-components. A quick look at the GitHub PR shows that `refactoring` is still the correct tag.

While fixing it up, did a quick grammar and presentation pass through the notes and questions. Don't hesitate to drop that commit.
