### PR TITLE
n19339 post-meeting url fixups

### DIFF
--- a/_posts/2020-08-26-#19339.md
+++ b/_posts/2020-08-26-#19339.md
@@ -223,7 +223,7 @@ commit: 67bb714
 19:23 <jnewbery> it's impossible to broadcast something that isn't in your mempool
 19:23 <robot-dreams> unlike testmempoolaccept, sendrawtransaction calls into `BroadcastTransaction`, which (i) calls ATMP a second time with `test_accept = true` and (ii) does some extra bookkeeping
 19:23 <dhruvmehta> test_accept=1 is a dry run. It runs policy checks and signature checks which are cached though so a second "actual" run is significantly cheaper.
-19:23 <gzhao408> for reference testmempoolaccept and sendrawtransaction can be found here: https://github.com/bitcoin/bitcoin/blob/master/src/rpc/rawtransaction.cpp#L800
+19:23 <gzhao408> for reference testmempoolaccept and sendrawtransaction can be found here: https://github.com/bitcoin/bitcoin/blob/c831e105/src/rpc/rawtransaction.cpp#L858 and https://github.com/bitcoin/bitcoin/blob/c831e105/src/rpc/rawtransaction.cpp#L800
 19:24 <robot-dreams> Also, for some reason testmempoolaccept does an extra check `request.params[0].get_array().size() == 1` (maybe in the future, it's intended to test multiple transactions in a single RPC?)
 19:25 <sipa> robot-dreams: ah the age old dream of package relay :)
 19:25 <gzhao408> 👌 thanks robot-dreams and dhruvmehta for the explanations!


### PR DESCRIPTION
Fix one semi-confusing link between two sections in line 226.