### PR TITLE
Component/labels update

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,6 +30,7 @@ DESIRED_COMPONENTS = [
   'Descriptors',
   'Docs',
   'GUI',
+  'Interfaces',
   'Mempool',
   'Mining',
   'P2P',

--- a/_posts/2020-06-10-#19105.md
+++ b/_posts/2020-06-10-#19105.md
@@ -4,7 +4,7 @@ date: 2020-06-10
 title: "Add Muhash3072 implementation in Python"
 pr: 19105
 authors: ["sipa", "fjahr"]
-components: ["tests", "crypto"]
+components: ["tests", "cryptography"]
 host: fjahr
 status: past
 commit: a6ee4c2cee


### PR DESCRIPTION
- Update `DESIRED_COMPONENTS` in the Rakefile with the Bitcoin Core `Interfaces` label in https://github.com/bitcoin/bitcoin/labels
- Standardize our in-house `cryptography` component (currently 19105 has component "crypto" and the 19055-2 has "cryptography")