### PR TITLE
Fix two small typos in n20079

### DIFF
--- a/_posts/2020-11-18-#20079.md
+++ b/_posts/2020-11-18-#20079.md
@@ -30,7 +30,7 @@ commit:
 
 - Today's pull request 20079 was created as a follow up to [PR
   19723](https://github.com/bitcoin/bitcoin/pull/19723), which changed how
-  non-verack messages are treated when the peer hasn't yet send a verack
+  non-verack messages are treated when the peer hasn't yet sent a verack
   message.
 
 ## Questions
@@ -46,7 +46,7 @@ commit:
 4. How are incorrect message from peers dealt with during the handshake? How
    does the pull request change that?
 
-5. What are the risks or benefits of disconecting a peer?
+5. What are the risks or benefits of disconnecting a peer?
 
 6. What are your thoughts on balancing the risks and benefits of disconnecting
    peers? What should be used as criteria to disconnect a peer?


### PR DESCRIPTION
Fix two small typos in n20079:

- `send` -> `sent`
- `disconecting` -> `disconnecting`