### PR TITLE
Redecorate with dark theme

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,6 +9,7 @@
   </title>
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta charset="UTF-8">
 
   <link rel="stylesheet" href="{{ site.github.url }}/assets/css/all.css">
   <link rel="stylesheet" href="/assets/css/font-awesome.min.css">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,7 +23,7 @@
 <script>
   function save() {
     const dark = document.getElementById('color-mode').checked;
-    window.localStorage.setItem('dark', dark);
+    window.localStorage.setItem('dark', String(dark));
   }
 
   const dark = window.localStorage.getItem('dark') === "true";

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,6 +5,9 @@
 
 <body>
 
+  <input id="color-mode" type="checkbox" name="color-mode" onclick='save()'>
+  <label id="color-mode-switch" for="color-mode">💡</label>
+
   <div class="site-container">
 
     {% include header.html %}
@@ -16,5 +19,15 @@
   <div>
 
 </body>
+
+<script>
+  function save() {
+    const dark = document.getElementById('color-mode').checked;
+    window.localStorage.setItem('dark', dark);
+  }
+
+  const dark = window.localStorage.getItem('dark') === "true";
+  document.getElementById('color-mode').checked = dark;
+</script>
 
 </html>

--- a/assets/css/1-tools/_code.scss
+++ b/assets/css/1-tools/_code.scss
@@ -1,7 +1,7 @@
 pre,
 code {
     border-radius: 3px;
-    background-color: #f5f5f5;
+    background-color: var(--code-bg-color);
     font-family: "Source Code Pro";
     margin-top: 1rem;
     margin-bottom: 1rem;

--- a/assets/css/all.sass
+++ b/assets/css/all.sass
@@ -24,18 +24,27 @@ $large-screen: 1024px
 
 /* This is an example style sheet that comes default - just delete everything after this comment this to start from a blank slate */
 
+html
+  height: 100%
+
+body
+  height: 100%
+  min-height: 100%
+
 #color-mode
   display: none
 
 #color-mode-switch
   user-select: none
-  float: right
+  right: 0
+  position: absolute
 
 // Light (default)
 #color-mode:not(:checked) ~ .site-container
   --bg-color: white
   --text-color: black
   --link-color: #0000f0
+  --link-visited-color: #551b8c
   --code-bg-color: #f5f5f5
   --log-bg-color: #f0f0f0
   --log-color: #808080
@@ -47,6 +56,7 @@ $large-screen: 1024px
   --bg-color: black
   --text-color: white
   --link-color: #58a6ff
+  --link-visited-color: #824bb7
   --code-bg-color: #565656
   --log-bg-color: #565656
   --log-color: #080808
@@ -59,6 +69,9 @@ a
 a
   &:hover
     color: $secondary-color
+a
+  &:visited
+    color: var(--link-visited-color)
 
 .site-container
   max-width: 2250px
@@ -66,12 +79,16 @@ a
   padding: 1rem 2rem 0 2rem
   background-color: var(--bg-color)
   color: var(--text-color)
+  min-height: 100%
+  overflow: auto
 
 .logo
   text-decoration: none
   color: var(--text-color)
   font:
     size: 48px
+  a
+    color: var(--text-color)
 
 .dt-published
   color: #828282

--- a/assets/css/all.sass
+++ b/assets/css/all.sass
@@ -67,11 +67,12 @@ a
   color: var(--link-color)
 
 a
-  &:hover
-    color: $secondary-color
-a
   &:visited
     color: var(--link-visited-color)
+
+a
+  &:hover
+    color: $secondary-color
 
 .site-container
   max-width: 2250px

--- a/assets/css/all.sass
+++ b/assets/css/all.sass
@@ -24,6 +24,38 @@ $large-screen: 1024px
 
 /* This is an example style sheet that comes default - just delete everything after this comment this to start from a blank slate */
 
+#color-mode
+  display: none
+
+#color-mode-switch
+  user-select: none
+  float: right
+
+// Light (default)
+#color-mode:not(:checked) ~ .site-container
+  --bg-color: white
+  --text-color: black
+  --link-color: #0000f0
+  --code-bg-color: #f5f5f5
+  --log-bg-color: #f0f0f0
+  --log-color: #808080
+  --target-color: #dddddd
+  --meeting-index-color: #606060
+
+// Dark
+#color-mode:checked ~ .site-container
+  --bg-color: black
+  --text-color: white
+  --link-color: #58a6ff
+  --code-bg-color: #565656
+  --log-bg-color: #565656
+  --log-color: #080808
+  --target-color: #3a3939
+  --meeting-index-color: #8c5e5e
+
+a
+  color: var(--link-color)
+
 a
   &:hover
     color: $secondary-color
@@ -32,10 +64,12 @@ a
   max-width: 2250px
   margin: 0
   padding: 1rem 2rem 0 2rem
+  background-color: var(--bg-color)
+  color: var(--text-color)
 
 .logo
   text-decoration: none
-  color: $primary-color
+  color: var(--text-color)
   font:
     size: 48px
 
@@ -52,7 +86,7 @@ a
   font-size: 0.95em
 
 \:target
-  background: #ddd
+  background: var(--target-color)
 
 .question
   font-size: 1.2em
@@ -61,7 +95,7 @@ a
 .meetings-index-section
   margin-top: 0.4em
   margin-bottom: 0.4em
-  color: #606060
+  color: var(--meeting-index-color)
 
 .Home-posts-post-date
   min-width: 94px
@@ -87,16 +121,16 @@ a
   vertical-align: top
 
 .log-lineno
-  background-color: #f0f0f0
+  background-color: var(--log-bg-color)
   \:target
-    background-color: #ddd
+    background-color: var(--target-color)
   a
-    color: grey
+    color: (--log-color)
     text-decoration: none
     user-select: none
 
 .log-time
-  color: blue
+  color: var(--link-color)
   padding-left: 6px
   padding-right: 6px
 


### PR DESCRIPTION
Offering this for late night review club crammers to make the site easier on the eyes. For IRC logs, I switched out a few colors for better contrast against the dark background.

Here's some examples screen shots showing main page, IRC log, and a `code` block...

##

![Screen Shot 2021-02-17 at 9 59 48 AM](https://user-images.githubusercontent.com/2084648/108223356-ba587080-7107-11eb-98dd-f329f741edbd.png)

##

![Screen Shot 2021-02-17 at 10 00 00 AM](https://user-images.githubusercontent.com/2084648/108223355-ba587080-7107-11eb-90a3-59ee036e5d9e.png)

##

![Screen Shot 2021-02-17 at 10 01 33 AM](https://user-images.githubusercontent.com/2084648/108223353-ba587080-7107-11eb-95ec-c3baa022b9e1.png)
