### PR TITLE
Fix a host's handle

### DIFF
--- a/_posts/2021-02-10-#18261.md
+++ b/_posts/2021-02-10-#18261.md
@@ -5,7 +5,7 @@ title: "Erlay: bandwidth-efficient transaction relay protocol"
 pr: 18261
 authors: [naumenkogs]
 components: ["p2p"]
-host: lightlike
+host: mzumsande
 status: past
 commit: c452e5d
 ---


### PR DESCRIPTION
One of the review clubs that lightlike/mzumsande hosted was mapped to the irc handle instead of github. 