### PR TITLE
Remove max-width from site-container

### DIFF
--- a/assets/css/all.sass
+++ b/assets/css/all.sass
@@ -75,7 +75,6 @@ a
     color: $secondary-color
 
 .site-container
-  max-width: 2250px
   margin: 0
   padding: 1rem 2rem 0 2rem
   background-color: var(--bg-color)


### PR DESCRIPTION

![Screenshot_2021-04-02 Multiprocess Add basic spawn and IPC support(1)](https://user-images.githubusercontent.com/8077169/113419737-57c1e800-93c8-11eb-941a-1e3bbe4b9022.png)


There is a white edge on large screens when darkmode is enabled. (See screenshot)
(Not sure if this is a concern but this fix would make lines longer on screens that are wider than 2250 pixels.)