### PR TITLE
Differentiate the titles of Python Minisketch meetings 1 and 2

### DIFF
--- a/_posts/2021-02-17-minisketch-#26.md
+++ b/_posts/2021-02-17-minisketch-#26.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 date: 2021-02-17
-title: "Add Python implementation of Minisketch"
+title: "Add Python implementation of Minisketch, part 1"
 link: https://github.com/sipa/minisketch/pull/26
 authors: [sipa]
 components: ["math and cryptography"]

--- a/_posts/2021-03-03-minisketch-#26-2.md
+++ b/_posts/2021-03-03-minisketch-#26-2.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 date: 2021-03-03
-title: "Add Python implementation of Minisketch"
+title: "Add Python implementation of Minisketch, part 2"
 link: https://github.com/sipa/minisketch/pull/26
 authors: [sipa]
 components: ["math and cryptography"]


### PR DESCRIPTION
as they currently appear the same apart from the date in the meetings listings.
