### PR TITLE
fix inaccurate note and weird question in 18418 notes

### DIFF
--- a/_posts/2021-05-19-#18418.md
+++ b/_posts/2021-05-19-#18418.md
@@ -39,8 +39,8 @@ The `OUTPUT_GROUP_MAX_ENTRIES` constant limits the number of UTXOs per
 	- Within `GroupOutputs()`, if we have more than
 	  `OUTPUT_GROUP_MAX_ENTRIES` with the same scriptPubKey, we batch them
 into multiple `OutputGroup`s with up to `OUTPUT_GROUP_MAX_ENTRIES` UTXOs each.
-	- If we are avoiding "partial spends," we won't include non-full
-	  `OutputGroup`s in coin selection.
+If we are excluding "partial groups," we won't use non-full
+`OutputGroup`s in coin selection.
 
 * [PR#18418](https://github.com/bitcoin/bitcoin/pull/18418) increases
   `OUTPUT_GROUP_MAX_ENTRIES` from 10 to 100. The number 100 was suggested
@@ -76,16 +76,7 @@ NACK](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#peer-review
 What was your review approach?
 
 2. What do the `avoid_reuse` wallet flag and `-avoidpartialspends` wallet
-options do?  Which of the following combinations are possible / make sense?
-
-	(A) `avoid_reuse = true, avoidpartialspends = true`
-
-	(B) `avoid_reuse = true, avoidpartialspends = false`
-
-	(C) `avoid_reuse = false, avoidpartialspends = true`
-
-	(D) `avoid_reuse = false, avoidpartialspends = false`
-
+   options do? Why might we want one to automatically turn on the other?
 
 3. If your wallet has 101 UTXOs of 0.01 BTC each, all sent to the same
 scriptPubKey, and tries to send a payment of 0.005 BTC, avoiding partial
@@ -108,11 +99,11 @@ increasing `OUTPUT_GROUP_MAX_ENTRIES`?
 specifically?
 
 8. For the purpose of coin selection, what's the difference between
-`m_avoid_partial_spends` and `m_include_partial_groups` in
-`CoinEligibilityFilter` (Hint: `m_avoid_partial_spends` becomes
-`separate_coins` in `GroupOutputs()`)?
+   [`CoinEligibilityFilter.include_partial_groups`](https://github.com/bitcoin-core-review-club/bitcoin/blob/4ac1adda9914d845aaea5804af4801ffec53c701/src/wallet/coinselection.h#L65)
+and
+[`CoinSelectionParams.avoid_partial_spends`](https://github.com/bitcoin/bitcoin/blob/241e14162fdfdddf697536113a68a3b11449db63/src/wallet/wallet.h#L618)
 
-
+ (Hint: `m_avoid_partial_spends` becomes `separate_coins` in `GroupOutputs()`)?
 <!-- TODO: After meeting, uncomment and add meeting log between the irc tags ##
 Meeting Log
 

--- a/_posts/2021-05-19-#18418.md
+++ b/_posts/2021-05-19-#18418.md
@@ -14,96 +14,95 @@ commit: 241e141
 
 * The way our wallet constructs transactions over time can leak information
   about its contents.  The most obvious example is we can assume that all UTXOs
-sent to the same scriptPubKey are controlled by the same person. UTXOs sent to
-different addresses may also be linked if they are spent together (a common
-heuristic used in chain analysis).  Thus, if we're not careful, observant
-attackers can link addresses to estimate our wallet balance and, if any one of
-our addresses is deanonymized (e.g. we send it to an exchange, merchant, or
-block explorer that knows our personal information or IP address), we might
-accidentally reveal how much money we have!
+  sent to the same scriptPubKey are controlled by the same person. UTXOs sent to
+  different addresses may also be linked if they are spent together (a common
+  heuristic used in chain analysis).  Thus, if we're not careful, observant
+  attackers can link addresses to estimate our wallet balance and, if any one of
+  our addresses is deanonymized (e.g. we send it to an exchange, merchant, or
+  block explorer that knows our personal information or IP address), we might
+  accidentally reveal how much money we have!
 
 * The Bitcoin Core wallet implements a few best-practice privacy techniques.
   One is avoiding the reuse of addresses when creating an invoice or change
-address.  Another is grouping UTXOs into
-[OutputGroup](https://github.com/bitcoin-core-review-club/bitcoin/blob/4ac1adda9914d845aaea5804af4801ffec53c701/src/wallet/coinselection.h#L72)s
-by scriptPubKey and running coin selection on the groups rather than individual
-UTXOs.
+  address.  Another is grouping UTXOs into
+  [OutputGroup](https://github.com/bitcoin-core-review-club/bitcoin/blob/4ac1adda9914d845aaea5804af4801ffec53c701/src/wallet/coinselection.h#L72)s
+  by scriptPubKey and running coin selection on the groups rather than individual
+  UTXOs.
 
-* However, `OutputGroup`s can grow quite large - after all, anyone can send as
-  many transactions as they want to an address that we've published. It might
-not make sense to fund a 0.015BTC transaction by sweeping a group of 150 inputs
-worth 10BTC (not to mention the extra fees for all the unnecessary inputs).
-The `OUTPUT_GROUP_MAX_ENTRIES` constant limits the number of UTXOs per
-`OutputGroup`.
+* However, each `OutputGroup` can grow quite large. It might
+  not make sense to fund a 0.015BTC transaction by sweeping a group of 150 inputs
+  worth 10BTC (not to mention the extra fees for all the unnecessary inputs).
+  The `OUTPUT_GROUP_MAX_ENTRIES` constant limits the number of UTXOs per
+  `OutputGroup`.
 
-	- Within `GroupOutputs()`, if we have more than
-	  `OUTPUT_GROUP_MAX_ENTRIES` with the same scriptPubKey, we batch them
-into multiple `OutputGroup`s with up to `OUTPUT_GROUP_MAX_ENTRIES` UTXOs each.
-If we are excluding "partial groups," we won't use non-full
-`OutputGroup`s in coin selection.
+  - Within `GroupOutputs()`, if we have more than
+    `OUTPUT_GROUP_MAX_ENTRIES` with the same scriptPubKey, we batch them
+    into multiple `OutputGroup`s with up to `OUTPUT_GROUP_MAX_ENTRIES` UTXOs each.
+    If we are excluding "partial groups," we won't use non-full
+    `OutputGroup`s in coin selection.
 
 * [PR#18418](https://github.com/bitcoin/bitcoin/pull/18418) increases
   `OUTPUT_GROUP_MAX_ENTRIES` from 10 to 100. The number 100 was suggested
-during a [previous review club](https://bitcoincore.reviews/17824.html#l-339).
-This behavior change constitutes just one line (and some adjustments to the
-tests), but it is ripe with opportunities to explore how coin selection works.
+  during a [previous review club](https://bitcoincore.reviews/17824.html#l-339).
+  This behavior change constitutes just one line (and some adjustments to the
+  tests), but it is ripe with opportunities to explore how coin selection works.
 
 * Try adding some log statements, re-compiling and then re-running the tests
-  (Hint: `test/functional/combine_logs.py` to see logs, and you can assert that
-your logs are printed by adding `with
-node.assert_debug_log(expected_msg=[your_log_statement])` to the functional
-test).
+  (hint: you can use `test/functional/combine_logs.py` to see logs, and you
+  assert that your logs are printed by adding `with
+  node.assert_debug_log(expected_msg=[your_log_statement])` to the functional
+  test).
 
-	- Some good tests to play around with are wallet\_avoidreuse.py and
-	  wallet\_groups.py.
-	- The PR author, fjahr, has written an excellent [guide to
-debugging Bitcoin Core](https://github.com/fjahr/debugging_bitcoin) with some
-hints on adding logging and using debuggers.
-	- You can also tinker with some of the constants (maybe poke around for
-	  off-by-one errors) and see if things break!
+  - Some good tests to play around with are `wallet_avoidreuse.py` and
+    `wallet_groups.py`.
+  - The PR author, fjahr, has written an excellent [guide to
+    debugging Bitcoin Core](https://github.com/fjahr/debugging_bitcoin) with some
+    hints on adding logging and using debuggers.
+  - You can also tinker with some of the constants (maybe poke around for
+    off-by-one errors) and see if things break!
 
 * You may find some previous review clubs helpful:
 
-	- Review Club [#17824](/17824) discussed the `avoid_reuse` flag.
-	- Review Clubs [#17331](/17331) and [#17526](/17526) discussed coin
-	  selection.
-
+  - Review Club [#17824](/17824) discussed the `avoid_reuse` flag.
+  - Review Clubs [#17331](/17331) and [#17526](/17526) discussed coin
+    selection.
 
 ## Questions
 
 1. Did you review the PR? [Concept ACK, approach ACK, tested ACK, or
-NACK](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#peer-review)?
-What was your review approach?
+   NACK](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#peer-review)?
+   What was your review approach?
 
 2. What do the `avoid_reuse` wallet flag and `-avoidpartialspends` wallet
-   options do? Why might we want one to automatically turn on the other?
+   option do? Why might we want one to automatically turn on the other?
 
 3. If your wallet has 101 UTXOs of 0.01 BTC each, all sent to the same
-scriptPubKey, and tries to send a payment of 0.005 BTC, avoiding partial
-spends, how many inputs will the resulting transaction have (Hint: this is
-almost exactly the `test_full_destination_group_is_preferred` test case in
-wallet\_avoidreuse.py).
+   scriptPubKey, and tries to send a payment of 0.005 BTC, avoiding partial
+   spends, how many inputs will the resulting transaction have (Hint: this is
+   almost exactly the `test_full_destination_group_is_preferred` test case in
+   wallet\_avoidreuse.py).
 
 4. In that test case, what is the fee amount paid for the 0.5BTC transaction?
-(Hint: try `import pdb; pdb.set_trace()` and call the
-[gettransaction](https://developer.bitcoin.org/reference/rpc/gettransaction.html)
-RPC).
+   (Hint: try `import pdb; pdb.set_trace()` and call the
+   [gettransaction](https://developer.bitcoin.org/reference/rpc/gettransaction.html)
+   RPC).
 
 5. Can you have multiple UTXOs under the same address if you set
-`avoid_reuse=true`?
+   `avoid_reuse=true`?
 
 6. What are the advantages, disadvantages, and potential risks to users of
-increasing `OUTPUT_GROUP_MAX_ENTRIES`?
+   increasing `OUTPUT_GROUP_MAX_ENTRIES`?
 
 7. What do you think of increasing `OUTPUT_GROUP_MAX_ENTRIES` to 100,
-specifically?
+   specifically?
 
 8. For the purpose of coin selection, what's the difference between
    [`CoinEligibilityFilter.include_partial_groups`](https://github.com/bitcoin-core-review-club/bitcoin/blob/4ac1adda9914d845aaea5804af4801ffec53c701/src/wallet/coinselection.h#L65)
-and
-[`CoinSelectionParams.avoid_partial_spends`](https://github.com/bitcoin/bitcoin/blob/241e14162fdfdddf697536113a68a3b11449db63/src/wallet/wallet.h#L618)
+   and
+   [`CoinSelectionParams.avoid_partial_spends`](https://github.com/bitcoin/bitcoin/blob/241e14162fdfdddf697536113a68a3b11449db63/src/wallet/wallet.h#L618)?
 
- (Hint: `m_avoid_partial_spends` becomes `separate_coins` in `GroupOutputs()`)?
+   (Hint: `m_avoid_partial_spends` becomes `separate_coins` in `GroupOutputs()`)
+
 <!-- TODO: After meeting, uncomment and add meeting log between the irc tags ##
 Meeting Log
 


### PR DESCRIPTION
While I was reviewing the question about `CoinEligibilityFilter.include_partial_groups` vs `CoinSelectionParams.avoid_partial_spends`, I realized I mixed them up in the notes 🤦 fixed that and added links.
Also, I felt like the multiple choice thing in Q2 was a little weird, so I changed it to a more discussion-y question.