### PR TITLE
Add max-width attribute to limit page width

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,13 +9,11 @@
   <label id="color-mode-switch" for="color-mode">💡</label>
 
   <div class="site-container">
-
-    {% include header.html %}
-
-    {{ content }}
-
-    {% include footer.html %}
-
+    <div class="page-content">
+      {% include header.html %}
+      {{ content }}
+      {% include footer.html %}
+    <div>
   <div>
 
 </body>

--- a/assets/css/all.sass
+++ b/assets/css/all.sass
@@ -82,6 +82,10 @@ a
   min-height: 100%
   overflow: auto
 
+.page-content
+  max-width: 1200px
+  margin: 0 auto
+
 .logo
   text-decoration: none
   color: var(--text-color)


### PR DESCRIPTION
Text is more difficult to read when the columns are very wide. Limit the maximum website width to 1200px to prevent very long lines.