### PR TITLE
fix PR URL display text

### DIFF
--- a/_layouts/pr.html
+++ b/_layouts/pr.html
@@ -33,7 +33,7 @@ layout: default
     {% if page.pr %}
       <p style="font-weight:bold">
         <a href="https://github.com/bitcoin/bitcoin/pull/{{ page.pr }}">
-          https://github.com/bitcoin/bitcoin/pulls/{{ page.pr }}
+          https://github.com/bitcoin/bitcoin/pull/{{ page.pr }}
         </a>
       </p>
     {% elsif page.link %}


### PR DESCRIPTION
Finally realized why I keep posting the wrong link during review club meetings - the link always points to the right page, but if you copy-paste the text, there's an extra s in the url

before:
<img width="368" alt="image" src="https://user-images.githubusercontent.com/25183001/127374611-c909a1f2-94f7-4aae-82a3-c8147a4a8b16.png">

after:
<img width="370" alt="image" src="https://user-images.githubusercontent.com/25183001/127374807-345049b7-1371-47f6-b7ee-d81e28fbae19.png">
