### PR TITLE
fix n23614 irc log (broken timestamp)

### DIFF
--- a/_posts/2021-12-01-#23614.md
+++ b/_posts/2021-12-01-#23614.md
@@ -122,7 +122,7 @@ automatically by using `SetMockTime()` to fast-forward?
 17:15 <glozow> raj: indeed. does anyone know how we make sure the peer only relays blocks to us?
 17:15 <stickies-v> setting the fRelay flag to false in the version message
 17:15 <glozow> bonus question: do we only relay blocks to them?
-17:15:52] <glozow> stickies-v: correct! and what happens if they send us an unconfirmed transaction?
+17:15 <glozow> stickies-v: correct! and what happens if they send us an unconfirmed transaction?
 17:16 <stickies-v> disconnect I think?
 17:16 <raj> Not necessarily I would guess.. They might not have us as block relay only? 
 17:16 <brunoerg> we discard it and disconnect?


### PR DESCRIPTION
Line 50 in the IRC log for n23614 currently looks odd:

<img width="510" alt="image" src="https://user-images.githubusercontent.com/91535/144488987-0161587d-278c-43d6-b170-9b937f4b23ea.png">

Correcting the timestamp should hopefully fix that.