### PR TITLE
Show irc channel name more prominently

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ coordinator:       "Bitcoin Core contributor [glozow](https://github.com/glozow)
 coordinator_irc:   "glozow"
 description:       "A weekly review club for Bitcoin Core PRs"
 meeting_day:       "Wednesday"
-meeting_location:  "#bitcoin-core-pr-reviews IRC channel on [libera.chat](https://kiwiirc.com/nextclient/irc.libera.chat/)"
+meeting_location:  'the #bitcoin-core-pr-reviews IRC channel on <a href="https://kiwiirc.com/nextclient/irc.libera.chat/">libera.chat</a>'
 meeting_time:      "17:00 UTC"
 title:             "Bitcoin Core PR Review Club"
 twitter:

--- a/_layouts/pr.html
+++ b/_layouts/pr.html
@@ -25,8 +25,8 @@ layout: default
       {{ page.date | date: date_format }}
       {% if page.status == "upcoming" %}
         {{ site.meeting_time }}
-        at
-        {{ site.meeting_location }}
+        in
+        {{ site.meeting_location }}.
       {%- endif -%}
     </time>
 

--- a/index.md
+++ b/index.md
@@ -10,8 +10,7 @@ Bitcoin Core PRs at **{{ site.meeting_time }} on {{ site.meeting_day }}s** in
 
 <span class="question">What's it for?</span> &nbsp;To help newer contributors
 learn about the Bitcoin Core review process. The review club is *not* primarily
-intended to help open PRs get merged (although that might be a nice
-side-effect).
+intended to help open PRs get merged.
 
 <span class="question">Who should take part?</span> &nbsp;Anyone who wants to
 learn about contributing to Bitcoin Core. All are welcome to come and ask

--- a/index.md
+++ b/index.md
@@ -5,7 +5,8 @@ title: home
 ### A weekly review club for Bitcoin Core PRs
 
 <span class="question">What is this?</span> &nbsp;A weekly club for reviewing
-Bitcoin Core PRs at **{{ site.meeting_time }} on {{ site.meeting_day }}s** on IRC.
+Bitcoin Core PRs at **{{ site.meeting_time }} on {{ site.meeting_day }}s** in
+{{ site.meeting_location }}.
 
 <span class="question">What's it for?</span> &nbsp;To help newer contributors
 learn about the Bitcoin Core review process. The review club is *not* primarily

--- a/your-first-meeting.md
+++ b/your-first-meeting.md
@@ -8,7 +8,7 @@ title: Attending your first PR Review Club
 If you’re thinking about attending PR Review Club, welcome! We love new
 participants. Below is information to help you get started as a first-timer.
 
-The club meets on {{ site.meeting_day }}s at {{ site.meeting_time }} on the
+The club meets on {{ site.meeting_day }}s at {{ site.meeting_time }} in
 {{ site.meeting_location }}. Every week, a Bitcoin protocol
 developer will host a 60-minute discussion on a Bitcoin Core pull request. [The
 code of conduct](https://bitcoincore.reviews/code-of-conduct) details the


### PR DESCRIPTION
We lost the channel name from the front page somewhere along the way.