### PR TITLE
remove components from PR titles

### DIFF
--- a/_posts/2020-03-18-#18113.md
+++ b/_posts/2020-03-18-#18113.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 date: 2020-03-18
-title: "Coins: Don't allow a coin to be spent and FRESH. Improve commenting."
+title: "Don't allow a coin to be spent and FRESH. Improve commenting."
 pr: 18113
 authors: [jnewbery]
 components: ["utxo db and indexes"]

--- a/_posts/2020-04-15-#18521.md
+++ b/_posts/2020-04-15-#18521.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 date: 2020-04-15
-title: "Fuzz: Add process_messages harness"
+title: "Add process_messages fuzz harness"
 pr: 18521
 authors: [MarcoFalke]
 components: ["tests"]

--- a/_posts/2020-09-16-#19845.md
+++ b/_posts/2020-09-16-#19845.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 date: 2020-09-16
-title: "Net: CNetAddr: add support to (un)serialize as ADDRv2"
+title: "Add support to (un)serialize as ADDRv2"
 pr: 19845
 authors: [vasild, dongcarl]
 components: ["p2p"]

--- a/_posts/2021-03-17-#21142.md
+++ b/_posts/2021-03-17-#21142.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 date: 2021-03-17
-title: "Fuzz: Add tx_pool fuzz target"
+title: "Add tx_pool fuzz target"
 pr: 21142
 authors: [MarcoFalke]
 components: ["tests"]

--- a/_posts/2021-07-28-#22155.md
+++ b/_posts/2021-07-28-#22155.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 date: 2021-07-28
-title: "Wallet test: Add test for subtract fee from recipient behavior"
+title: "Add test for subtract fee from recipient behavior"
 pr: 22155
 authors: [ryanofsky]
 components: ["tests", "wallet"]

--- a/_posts/2021-08-11-#20295.md
+++ b/_posts/2021-08-11-#20295.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 date: 2021-08-11
-title: "rpc: getblockfrompeer"
+title: "RPC getblockfrompeer"
 pr: 20295
 authors: [Sjors]
 components: ["p2p","rpc/rest/zmq"]

--- a/_posts/2021-09-01-#22675.md
+++ b/_posts/2021-09-01-#22675.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 date: 2021-09-01
-title: "policy: extract RBF logic into policy/rbf"
+title: "Extract RBF logic into policy/rbf"
 pr: 22675
 authors: [glozow]
 components: ["refactoring", "tx fees and policy", "validation"]

--- a/_posts/2021-11-24-#23512.md
+++ b/_posts/2021-11-24-#23512.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 date: 2021-11-24
-title: "policy: Treat taproot as always active"
+title: "Treat taproot as always active"
 pr: 23512
 authors: [MarcoFalke]
 components: ["tx fees and policy"]

--- a/_posts/2021-12-15-#23724.md
+++ b/_posts/2021-12-15-#23724.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 date: 2021-12-15
-title: "add systemtap's sys/sdt.h as depends for GUIX builds with USDT tracepoints"
+title: "Add systemtap's sys/sdt.h as depends for GUIX builds with USDT tracepoints"
 pr: 23724
 authors: ["0xB10C"]
 components: ["build system", "utils/log/libs"]

--- a/_posts/2022-02-16-#23542.md
+++ b/_posts/2022-02-16-#23542.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 date: 2022-02-16
-title: "open p2p connections to nodes that listen on non-default ports"
+title: "Open p2p connections to nodes that listen on non-default ports"
 pr: 23542
 authors: [vasild]
 components: ["p2p"]


### PR DESCRIPTION
Redundant info (already in the component tags) and clutters the titles.