### PR TITLE
Update meeting notes for v23-rc-testing

### DIFF
--- a/_posts/2022-03-30-v23-rc-testing.md
+++ b/_posts/2022-03-30-v23-rc-testing.md
@@ -23,7 +23,17 @@ commit:
   essential that the rcs are thoroughly tested. This special review club
   meeting is for people who want to help with that vital review process.
 
-<!-- TODO: Add testing guide-->
+- This [Bitcoin Core Release Candidate Testing
+  Guide](https://github.com/stickies-v/bitcoin-devwiki/blob/master/23.0-Release-Candidate-Testing-Guide.md)(WIP) has a tutorial for testing the release candidate.
+
+    - It is recommended to go through the "Preparation" steps ahead of the meeting, especially if you want to compile from source.
+    - The testing guide relies on the tools `jq` and `watch`, which are not installed by default on each platform. For example on macOS, you can install these ahead of time using `brew install`. Alternatively, you can also modify the instructions to avoid using these tools as they are not strictly necessary and/or can be replaced by other tools.
+    - For one of the tests, we try to connect over CJDNS. If you have not used this before, you could save some time by going through the [instructions](https://github.com/bitcoin/bitcoin/blob/master/doc/cjdns.md) and configuring this ahead of the meeting.
+
+- The guide is just to get you started on testing, so feel free to read the
+  [Release
+  Notes](https://github.com/bitcoin-core/bitcoin-devwiki/wiki/23.0-Release-Notes-draft)
+  and bring ideas of other things you'd like to test!
 
 
 <!-- TODO: After meeting, uncomment and add meeting log between the irc tags


### PR DESCRIPTION
I'm still getting some review and feedback on the guide, should be finalized on Monday. I'll push it to bitcoin-devwiki then, and update the link and remove the `WIP` disclaimer here. Not sure if you prefer to merge already or wait until it's live on the wiki?