### PR TITLE
Add shell command to sanitize logs from IRCCloud

### DIFF
--- a/hosting.md
+++ b/hosting.md
@@ -186,6 +186,17 @@ _This process is done by the review club maintainers_
   meeting log into it. Meeting logs should be copied exactly, but an `##
   Erratum` section can be added to correct factual errors.
 
+  - To sanitize logs exported from IRCCloud (ensure UTC timezone is selected
+    during export), use the following command on the unzipped .txt file:
+    ```sh
+    cat \#bitcoin-core-pr-reviews.txt \
+      | sed -n '/#startmeeting/h;//!H;$!d;x;//p' \
+      | sed '/#endmeeting/q' \
+      | sed '/[⇐→]/d' \
+      | cut -c 13-17,22- \
+      > sanitized_log.txt
+    ```
+
 - Change the `status` of the meeting post from `upcoming` to `past`.
   ```diff
   -status: upcoming
@@ -211,7 +222,7 @@ _This process is done by the review club maintainers_
     ```
 
   - The first time you do this, you'll need to add the review club bitcoin
-    repo to your git remotes: 
+    repo to your git remotes:
 
     ```shell
     git remote add review-club git@github.com:bitcoin-core-review-club/bitcoin.git


### PR DESCRIPTION
Should be faster than doing it manually. Every. Time. Again.

Discards everything before the _last_ `#startmeeting`  and the subsequent `#endmeeting` found in the logs; removes joined/left messages and converts datetime into timestamps.

Converts
```
...
[2022-05-11 16:59:46] <larryruane> thanks
[2022-05-11 17:00:23] <dongcarl> #startmeeting
[2022-05-11 17:00:30] <dongcarl> hello all
...
[2022-05-18 16:59:09] → Bayer joined (~Bayer@pop.92-184-117-40.mobile.abo.orange.fr)
[2022-05-18 16:59:47] → svav joined (~svav@82-69-86-143.dsl.in-addr.zen.co.uk)
[2022-05-18 17:00:11] <stickies-v> #startmeeting
[2022-05-18 17:00:16] <svav> Hi
...
[2022-05-18 17:05:33] <kouloumos> read the notes, didn't review code
[2022-05-18 17:05:33] → Azor joined (~Azor@200.109.50.144)
[2022-05-18 17:05:44] <svav> An intro to Output Descriptors https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md
...
[2022-05-18 18:02:23] <stickies-v> thank you all for bringing your A game today. Unfortunately we're out of time for this session, but there's more Miniscript joy next week. Same place, same time! Thank you again to darosior and sipa for guiding us all through this.
[2022-05-18 18:02:26] <stickies-v> #endmeeting
[2022-05-18 18:02:26] <__gotcha> First dive in cpp since more than 20 years, would not pretend to find sthing better
[2022-05-18 18:02:43] <svav> Thanks all
...
```
into
```
17:00 <stickies-v> #startmeeting
17:00 <svav> Hi
...
17:05 <kouloumos> read the notes, didn't review code
17:05 <svav> An intro to Output Descriptors https://github.com/bitcoin/bitcoin/blob/master/doc/
...
18:02 <stickies-v> thank you all for bringing your A game today. Unfortunately we're out of time for this session, but there's more Miniscript joy next week. Same place, same time! Thank you again to darosior and sipa for guiding us all through this.
18:02 <stickies-v> #endmeeting
```
