### PR TITLE
small fixups to n24148

### DIFF
--- a/_posts/2022-05-18-#24148.md
+++ b/_posts/2022-05-18-#24148.md
@@ -20,7 +20,7 @@ This is a 2-part Review Club. Since we haven't covered Miniscript before, we fir
 
 - In the [second part](https://bitcoincore.reviews/24148-2), we'll look at the Miniscript output descriptor implementation. We'll focus on the last 9 commits from "miniscript: tiny doc fixups" to "qa: functional test Miniscript watchonly support".
 
-- Some of the questions refer to changes introduced in the PR's predecessor [#24147](https://github.com/bitcoin/bitcoin/pull/24147) which introduced the bulk of the Miniscript logic into Bitcoin Core, so it may be helpful to gloss over that PR too. It also contains a more detailed overview of the various PRs involved in merging Miniscript into the Bitcoin Core codebase.
+- Some of the questions refer to changes introduced in the PR's predecessor [#24147](https://github.com/bitcoin/bitcoin/pull/24147) which introduced the bulk of the Miniscript logic into Bitcoin Core, so it may be helpful to review that PR too. It also contains a more detailed overview of the various PRs involved in merging Miniscript into the Bitcoin Core codebase.
 
 
 ### Introduction
@@ -31,7 +31,7 @@ This is a 2-part Review Club. Since we haven't covered Miniscript before, we fir
 
 - Descriptors combine well with Miniscript in allowing a wallet to handle tracking and signing for a larger variety of scripts. Since [Bitcoin Core 23.0](https://bitcoincore.org/en/releases/23.0/) descriptor wallets have become the default wallet type.
 
-- This PR [#24148](https://github.com/bitcoin/bitcoin/pull/24148) introduces watch-only support for Miniscript descriptors, extending the [already existing descriptor language](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md). You've probably noticed that both languages have very similar syntax, [this is intentional](https://github.com/bitcoin/bitcoin/pull/16800#issuecomment-583559190).
+- This PR [#24148](https://github.com/bitcoin/bitcoin/pull/24148) introduces watch-only support for Miniscript descriptors, extending the [already existing descriptor language](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md). You've probably noticed that both languages have very similar syntax; [this is intentional](https://github.com/bitcoin/bitcoin/pull/16800#issuecomment-583559190).
 
 
 ## Questions
@@ -56,7 +56,7 @@ This is a 2-part Review Club. Since we haven't covered Miniscript before, we fir
 
 1. Why is [`Node<Key>`]((https://github.com/darosior/bitcoin/blob/ec72f351134bed229baaefc8ffaa1f72688c5435/src/script/miniscript.h#L280)) templated with `Key`? What type(s) do we expect `Key` to take?
 
-1. Why is the Script size for a multi or thresh fragment depending on the value of the k threshold? https://github.com/bitcoin/bitcoin/blob/1511c9efb40524615ed47cc4e38af0735d536575/src/script/miniscript.cpp#L265
+1. Why is the Script [size](https://github.com/bitcoin/bitcoin/blob/1511c9efb40524615ed47cc4e38af0735d536575/src/script/miniscript.cpp#L265)for a multi or thresh fragment depending on the value of the k threshold?
 
 
 ## Meeting Log

--- a/_posts/2022-05-25-#24148-2.md
+++ b/_posts/2022-05-25-#24148-2.md
@@ -20,7 +20,7 @@ commit: ec72f35
 
 - Descriptors combine well with Miniscript in allowing a wallet to handle tracking and signing for a larger variety of scripts. Since [Bitcoin Core 23.0](https://bitcoincore.org/en/releases/23.0/) descriptor wallets have become the default wallet type.
 
-- This PR [#24148](https://github.com/bitcoin/bitcoin/pull/24148) introduces watch-only support for Miniscript descriptors, extending the [already existing descriptor language](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md). You've probably noticed that both languages have very similar syntax, [this is intentional](https://github.com/bitcoin/bitcoin/pull/16800#issuecomment-583559190).
+- This PR [#24148](https://github.com/bitcoin/bitcoin/pull/24148) introduces watch-only support for Miniscript descriptors, extending the [already existing descriptor language](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md). You've probably noticed that both languages have very similar syntax; [this is intentional](https://github.com/bitcoin/bitcoin/pull/16800#issuecomment-583559190).
 
 
 ## Questions


### PR DESCRIPTION
Mostly little nitpicks.

- Suggest "it may be helpful to review" instead of "it may be helpful to gloss over." It threw me off a little bit because I interpret "gloss over" to mean "handwave it away" or "pretend you covered something even though you didn't."

- Embed link instead of pasting as raw text

- Use semicolon instead of comma