### PR TITLE
push back v24-rc one week later

### DIFF
--- a/_posts/2022-09-28-v24-rc-testing.md
+++ b/_posts/2022-09-28-v24-rc-testing.md
@@ -1,6 +1,6 @@
 ---
 layout: pr
-date: 2022-09-21
+date: 2022-09-28
 title: "Testing Bitcoin Core 24.0 Release Candidates"
 components: ["tests"]
 host: kouloumos


### PR DESCRIPTION
@kouloumos and @glozow because RC1 will be ready later than expected, pushing back the testing review club by one week. Thanks for taking over the slot for the 21st, glozow!