### PR TITLE
fix formatting for n26158

### DIFF
--- a/_posts/2022-10-12-#26158.md
+++ b/_posts/2022-10-12-#26158.md
@@ -38,13 +38,13 @@ commit: cbc077e
 1. Which benchmarks do you think should/could be labeled as `LOW` or `MEDIUM` priority? What did you base that decision on?
 
 1. Quiz: Which of the following are valid `PriorityLevel`s:
-   * a. PriorityLevel{0x00}
-   * b. PriorityLevel{"low"}
-   * c. PriorityLevel::DEFAULT_PRIORITY_LEVEL
-   * d. PriorityLevel{3}
-   * e. PriorityLevel{4}
-   * f. PriorityLevel{0xff}
-   * g. auto static_cast<PriorityLevel>(8)
+   * a. `PriorityLevel{0x00}`
+   * b. `PriorityLevel{"low"}`
+   * c. `PriorityLevel::DEFAULT_PRIORITY_LEVEL`
+   * d. `PriorityLevel{3}`
+   * e. `PriorityLevel{4}`
+   * f. `PriorityLevel{0xff}`
+   * g. `auto static_cast<PriorityLevel>(8)`
 
 
 <!-- TODO: After meeting, uncomment and add meeting log between the irc tags


### PR DESCRIPTION
The `static_cast` currently isn't showing properly on the website:

<img width="198" alt="image" src="https://user-images.githubusercontent.com/69010457/195367703-68d03e8c-af88-4ece-824b-acfb15d6e518.png">
