### PR TITLE
manual fix for "Murch uploaded an image" 2022-10-26 n26265

### DIFF
--- a/_posts/2022-10-26-#26265.md
+++ b/_posts/2022-10-26-#26265.md
@@ -142,7 +142,7 @@ discussed this topic.
 17:17 <LarryRuane> bip 37
 17:18 <glozow> lightlike: idk!
 17:18 <stickies-v> we care about the non-witness distinction because (as part of the segwit upgrade) witness data is excluded from calculation of the merkle root
-17:18 — Murch uploaded an image: (83KiB) < https://libera.ems.host/_matrix/media/v3/download/matrix.org/zpgJxjvPsJXlQoqtIrMevKTN/image.png >
+17:18 <Murch> https://libera.ems.host/_matrix/media/v3/download/matrix.org/zpgJxjvPsJXlQoqtIrMevKTN/image.png 
 17:18 <instagibbs> lightlike, what would happen if your intuition was wrong? 
 17:18 <LarryRuane> lightlike: good q, I was wondering that exact thing too
 17:19 <LarryRuane> Murch: thank you!


### PR DESCRIPTION
At the review club on Oct 26, Murch uploaded an image, and I just happened to notice that this doesn't format well, at least on my browser (chrome):

https://bitcoincore.reviews/26265#l-71

The link isn't clickable, is somewhat mangled, and Murch's name is dropped off. I don't think it's worth automating this type of fixup (there are no other instances of this problem in the entire review club history), but if starts happening more often, we can consider it.