### PR TITLE
Improve IRC nickname parsing

### DIFF
--- a/_plugins/auto_logs_markup.rb
+++ b/_plugins/auto_logs_markup.rb
@@ -17,7 +17,7 @@ module Jekyll
     HH_MM = /^([0-1][0-9]|[2][0-3]):[0-5][0-9] .*/
 
     # Regex to select IRC <nick>.
-    IRC_NICK = /<.+?>/
+    IRC_NICK = /^(?:\s*)(<.+?>)/
 
     # Regex to select "<" and ">" chars.
     LT_GT = /[<>]/
@@ -55,7 +55,7 @@ module Jekyll
         # Separate the log line into useful parts.
         lineno  = "#{NON_BREAKING_SPACE * (LINE_DIGITS - index.to_s.size)}#{index}"
         time    = line[0..TIME_SIZE]
-        name    = IRC_NICK.match(line).to_s
+        name    = IRC_NICK.match(line[TIME_SIZE_PLUS_1..-1]).to_s
         nick    = name.gsub(LT_GT, '').strip
         color   = colors[nick] || (color_index = (color_index + 1) % NUM_COLORS ;
                                    colors[nick] = COLORS[color_index])

--- a/_posts/2022-10-26-#26265.md
+++ b/_posts/2022-10-26-#26265.md
@@ -142,7 +142,7 @@ discussed this topic.
 17:17 <LarryRuane> bip 37
 17:18 <glozow> lightlike: idk!
 17:18 <stickies-v> we care about the non-witness distinction because (as part of the segwit upgrade) witness data is excluded from calculation of the merkle root
-17:18 <Murch> https://libera.ems.host/_matrix/media/v3/download/matrix.org/zpgJxjvPsJXlQoqtIrMevKTN/image.png 
+17:18 — Murch uploaded an image: (83KiB) < https://libera.ems.host/_matrix/media/v3/download/matrix.org/zpgJxjvPsJXlQoqtIrMevKTN/image.png >
 17:18 <instagibbs> lightlike, what would happen if your intuition was wrong? 
 17:18 <LarryRuane> lightlike: good q, I was wondering that exact thing too
 17:19 <LarryRuane> Murch: thank you!


### PR DESCRIPTION
Fixes the IRC nickname parsing issue reported in #584 and reverts the manual fix since it is no longer necessary.

The updated nickname regex now matches the data _after_ the time stamp (`IRC_NICK.match(line[TIME_SIZE_PLUS_1..-1]).to_s`) and requires the `IRC_NICK` pattern to be at the beginning (`^`) of that (shortened) string, while allowing additional leading whitespaces in a non-capturing group (`(?:\s*)`). The leading whitespaces tolerance is because [n24098](https://github.com/bitcoin-core-review-club/website/blob/master/_posts/2022-02-23-%2324098.md?plain=1) has double whitespaces between timestamp and nickname (guess who added those logs?!). Instead of just fixing the logs in n24098, I think it makes sense to not have the parsing be unnecessarily strict?

cc @LarryRuane for reporting initial issue and @jonatack for previously improving this logic in #159 (making you the de facto expert 🥇)

## Testing
To verify the impact of this PR, one approach is to build the website using both versions and compare the diff in the `_site` folder which contains the html files.
To build, see the instructions in [README.md](https://github.com/bitcoin-core-review-club/website/blob/b3dd96a22a18acd8a7bb95940886ae9eaf4e7da1/README.md)

A simple script that does all of this:
```sh
# Create site contents on unfixed master (5110706) branch and copy to `unfixed/` dir
git checkout 5110706 && \
rm -rf _site/ && rm -rf unfixed && mkdir unfixed &&\
make && \
cp -r _site/ unfixed/ && \

# Create site contents on fixed PR branch and copy to `fixed/` dir
git checkout 3d3fd24 && \
rm -rf _site/ && rm -rf fixed && mkdir fixed &&\
make && \
cp -r _site/ fixed/  && \

# Compare the differences
# remove `-q` to see detailed diff
diff -r -q unfixed/ fixed/
```