### PR TITLE
Fix typos in n26265 and n26152

### DIFF
--- a/_posts/2022-10-26-#26265.md
+++ b/_posts/2022-10-26-#26265.md
@@ -14,10 +14,10 @@ commit: e5adc1a284a9292362e75501adc9f71ac6ecdf6e
 
 - Mempool policy
   [requires](https://github.com/bitcoin/bitcoin/blob/6d4048468430d9d1fe5e7c5fcda13708879d1083/src/validation.cpp#L699-L704)
-that transactions be at least 85 bytes (non-witness size). This rule was introduced in PR
+that transactions be at least 82 bytes (non-witness size). This rule was introduced in PR
 [#11423](https://github.com/bitcoin/bitcoin/pull/11423).
 The original justification given was "A transaction with 1 segwit input and 1 P2WPKH output has
-non-witness size of 85 bytes. Transactions smaller than this are not relayed to reduce unnecessary
+non-witness size of 82 bytes. Transactions smaller than this are not relayed to reduce unnecessary
 malloc overhead."
 
 - The true motivation was later documented as
@@ -31,7 +31,7 @@ clients](https://bitslog.com/2018/06/09/leaf-node-weakness-in-bitcoin-merkle-tre
 [proposed](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-March/016714.html) in PR
 #15482 to disallow transactions smaller than 65 bytes in consensus. This proposal has not been accepted.
 
-- PR [#26265](https://github.com/bitcoin/bitcoin/pull/26265) relaxes the policy rule from 85-byte
+- PR [#26265](https://github.com/bitcoin/bitcoin/pull/26265) relaxes the policy rule from 82-byte
   minimum to 65-byte minimum. Another approach could be to simply disallow 64-byte transactions.
 
 - The author also
@@ -48,7 +48,7 @@ discussed this topic.
 1. Did you review the PR? [Concept ACK, approach ACK, tested ACK, or
    NACK](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#peer-review)?
 
-1. Why was the minimum transaction size 85 bytes? Can you describe the attack? Why does setting this
+1. Why was the minimum transaction size 82 bytes? Can you describe the attack? Why does setting this
    policy help prevent the attack? Does it eliminate the attack vector entirely?
 
 1. What does "non-witness size" mean, and why do we care about the "non-witness" distinction?

--- a/_posts/2022-11-23-#26152.md
+++ b/_posts/2022-11-23-#26152.md
@@ -66,7 +66,7 @@ vsize are 1200sat and 600vB respectively, the coin's effective value would be 10
 
     - If the transaction replaces existing transactions in the mempool, one or multiple transactions
       may be evicted. After these evictions, some transactions may now need bumping, and others may
-      no longer need bumping. For example, if we may be replacing a previous CPFP child with an
+      no longer need bumping. For example, we may be replacing a previous CPFP child with an
       even higher feerate child.
 
 - [PR #26152](https://github.com/bitcoin/bitcoin/pull/26152) adds `MiniMiner`, a "mini" version of
@@ -99,21 +99,21 @@ fee to put on the transaction.
 
 1. What issue does this PR solve?
 
-1. We know that a transaction's individual feerate is not necessarily indicative of how a miner will
-  prioritize it. That is, if transaction X and Y have feerates fX and fY, fX > fY doesn't
-necessarily imply that X will be selected sooner than Y. If two independent mempool transactions X
-and Y have *ancestor feerates* gX and gY, which of the following are possible? (Here, "independent"
-means that their respective clusters have no overlapping transactions).
-
-    - X is selected sooner than Y
-    - X is selected later than Y
-
 1. In
    [`CalculateCluster`](https://github.com/bitcoin-core-review-club/bitcoin/commit/995107782a1a512811d54f7abf29249f351a7cbf#diff-c065d4cd2398ad0dbcef393c5dfc53f465bf44723348892395fffd2fb3bac522R1218),
 what does a transaction's "cluster" consist of?
 
 1. Why does the `MiniMiner` require an entire cluster? Why can't it just use the union of each
    transaction's ancestor sets?
+
+1. We know that a transaction's individual feerate is not necessarily indicative of how a miner will
+  prioritize it. That is, if transaction X and Y have feerates fX and fY, fX > fY doesn't
+necessarily imply that X will be selected sooner than Y. If two independent mempool transactions X
+and Y have *ancestor feerates* gX and gY where gX > gY, which of the following are possible? (Here,
+"independent" means that their respective clusters have no overlapping transactions).
+
+    - X is selected sooner than Y
+    - X is selected later than Y
 
 1. The `MiniMiner`
    [constructor](https://github.com/bitcoin-core-review-club/bitcoin/blob/b669fd94f84e679d4549ef0abe1b0483e1406152/src/node/mini_miner.h#L94)


### PR DESCRIPTION
- 82 bytes, not 85 bytes https://github.com/bitcoin/bitcoin/blob/60a00889b02cdb67ac20328af7477ff55ecd8e46/src/policy/policy.h#L29
- in #592, when I addressed review comments I added a grammatical error and an underspecified question oops