### PR TITLE
Introduce Topics and bidirectional links between pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,3 +20,5 @@ gem 'color_pound_spec_reporter'
 
 # HTTP bindings to libcurl - https://github.com/taf2/curb
 gem 'curb'
+
+gem "nokogiri", "~> 1.13.10"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,15 +55,20 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
+    mini_portile2 (2.8.1)
     minitest (5.14.2)
     minitest-reporters (1.4.2)
       ansi
       builder
       minitest (>= 5.0)
       ruby-progressbar
+    nokogiri (1.13.10)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (5.0.0)
+    racc (1.6.2)
     rake (13.0.1)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
@@ -92,7 +97,8 @@ DEPENDENCIES
   kramdown-parser-gfm
   minitest
   minitest-reporters
+  nokogiri (~> 1.13.10)
   rake
 
 BUNDLED WITH
-   2.1.4
+   2.3.26

--- a/Rakefile
+++ b/Rakefile
@@ -81,7 +81,7 @@ desc 'Create a new post file'
 namespace :posts do
   task :new do
     # Fetch user command line args. Exit if required args are missing.
-    pr, host, date = get_cli_options
+    pr, host, date = get_cli_options_posts
     handle_missing_required_arg('pr') unless pr
     handle_missing_required_arg('host') unless host
 
@@ -120,7 +120,7 @@ namespace :posts do
   end
 end
 
-def get_cli_options(options = {})
+def get_cli_options_posts(options = {})
   OptionParser.new do |opts|
     opts.banner = 'Usage: rake posts:new -- <options>'
     opts.on('-p', '--pr NUMBER', 'Pull request number (required)') do
@@ -143,8 +143,57 @@ def get_cli_options(options = {})
   [options[:pr], options[:host], options[:date]]
 end
 
-def handle_missing_required_arg(name)
-  puts "Error: Missing required --#{name} argument. Run `rake posts:new -- --help` for info."
+# To see the rake topics:new help, run:
+#   rake topics:new -- -H
+#
+desc 'Create a new topics file'
+namespace :topics do
+  task :new do
+    # Fetch user command line args. Exit if required args are missing.
+    title, slug = get_cli_options_topics
+    
+    handle_missing_required_arg('title', 'topics') unless title
+
+    # Slugify title if slug not supplied by user.
+    unless slug
+      slug = title.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
+      puts "Topic '#{title}' has been slugified and filename set to : #{slug}"
+    end
+    # Create a new topic file if none exists, otherwise exit.
+    filename = "#{'_topics/' if File.directory?('_topics')}#{slug}.md"
+
+    if File.file?(filename)
+      puts "Filename #{filename} already exists. Nothing done, exiting."
+    else
+      create_topic_file!(filename, title)
+      puts "New file #{filename} created successfully."
+    end
+    exit
+  end
+end
+
+def get_cli_options_topics(options = {})
+  OptionParser.new do |opts|
+    opts.banner = 'Usage: rake topics:new -- <options>'
+    opts.on('-t', '--title TOPIC_LONG', 'Long name for topic (required)') do
+      |title| options[:title] = title
+    end
+    opts.on('-s', '--slug TOPIC_SHORT',
+            'Short name for topic (optional, defaults to slugified title)') do
+      |slug| options[:slug] = slug
+    end
+    opts.on('-H', '--help', 'Display this help') do
+      puts opts
+      exit
+    end
+    args = opts.order!(ARGV) {}
+    opts.parse!(args)
+  end
+  [options[:title], options[:slug]]
+end
+
+def handle_missing_required_arg(name, rake = "posts")
+  puts "Error: Missing required --#{name} argument. Run `rake #{rake}:new -- --help` for info."
   exit
 end
 
@@ -222,6 +271,24 @@ def create_post_file!(filename, response, date, host)
     line.puts "{% irc %}"
     line.puts "{% endirc %}"
     line.puts "-->"
+  end
+end
+
+def create_topic_file!(filename, title)
+  def comment_out(line, header)
+    line.puts "<!-- uncomment to add"
+    line.puts "## #{header}"
+    line.puts "-->"
+  end
+
+  File.open(filename, 'w') do |line|
+    line.puts '---'
+    line.puts 'layout: topic'
+    line.puts "title: #{title}"
+    line.puts "---\n\n"
+    comment_out(line, "Notes")
+    comment_out(line, "History")
+    comment_out(line, "Resources")
   end
 end
 

--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,11 @@ exclude:
    - Rakefile
    - test/
 
+collections:
+  topics:
+    output: true
+    permalink: /topics/:slug
+
 defaults:
   - scope:
       path: ""  ## all pages

--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -6,5 +6,6 @@ author:
 menu:
 - {name: 'Home', url: ''}
 - {name: 'Meetings', url: 'meetings/'}
+- {name: 'Topics', url: 'topics/'}
 - {name: 'Code of Conduct', url: 'code-of-conduct/'}
 - {name: 'Hosting', url: 'hosting/'}

--- a/_includes/backlinks.html
+++ b/_includes/backlinks.html
@@ -1,0 +1,20 @@
+<side style="font-size: 0.9em">
+  {% if page.backlinks.size > 0 %}
+    <h3 style="margin-bottom: 1em; color: #828282">{{ page.backlinks.size }} Linked pages</h3>
+    <div style="display: grid; grid-gap: 1em; grid-template-columns: repeat(1fr);">
+      {% for backlink in page.backlinks %}
+        <div >
+          <a class="internal-link" style="font-size: 1.2em" href="{{ backlink.doc.url }}">{%- if backlink.doc.pr -%}#{{ backlink.doc.pr }}&nbsp;{%- endif -%}{{ backlink.doc.title }}</a><br>
+          <div style="margin-top: 0.3em; display: grid; grid-gap: 0.7em; grid-template-columns: repeat(1fr);">
+          {% for snippet in backlink.snippets %}
+            <div class="backlink-box">
+              <div class="backlink-header">{{ snippet.header }}</div>
+              {{ snippet.paragraph | link_to_anchor: backlink.doc.url | markdownify }}
+            </div>
+          {% endfor %}
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+  {% endif %}
+</side>

--- a/_layouts/pr.html
+++ b/_layouts/pr.html
@@ -65,5 +65,6 @@ layout: default
     <p>
       {{ content }}
     </p>
+    {% include backlinks.html %}
   </div>
 </section>

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -1,0 +1,22 @@
+---
+layout: default
+---
+
+<section>
+    <div class="post-content">
+      {% if page.code %}
+        <h1><code>{{ page.title }}</code></h1>
+      {% else %}
+        <h1>{{ page.title }}</h1>
+      {% endif %}
+  
+      <time class="dt-published" datetime="{{ page.last-modified-date | date_to_xmlschema }}">
+        Last updated: {{ page.last-modified-date | date: '%B %d, %Y' }}
+      </time>
+
+      <p>
+        {{ content }}
+      </p>
+      {% include backlinks.html %}
+    </div>
+</section>

--- a/_plugins/auto-anchor.rb
+++ b/_plugins/auto-anchor.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+# This file is based on code from https://github.com/bitcoinops/bitcoinops.github.io
+
+# Automatically adds id tags (anchors) to list items
+
+require 'digest/md5'
+
+def generate_slug(text)
+  # Remove double-quotes from titles before attempting to slugify
+  text.gsub!('"', '')
+  # Remove whitespace character from the end and use Liquid/Jekyll slugify filter
+  slug_text = "{{ \"#{text.rstrip}\" | slugify: 'latin' }}"
+  # use the digest library to create deterministic ids based on text
+  id = Digest::MD5.hexdigest(slug_text)[0...7]
+  slug = "\#b#{id}" # prefix with 'b', ids cannot start with a number
+  slug
+end
+
+def generate_anchor_list_link(anchor_link, class_name='anchor-list-link')
+  # custom clickable bullet linking to an anchor
+  "<a href=\"#{anchor_link}\" class=\"#{class_name}\">●</a>"
+end
+
+def auto_anchor(content)
+  # finds “bulleted” list items that start with hyphen (-) or asterisk (*)
+  # adds anchor and clickable bullet
+  content.gsub!(/^ *[\*-] .*?(?:\n\n|\z)/m) do |bulleted_paragraph|
+    slug = generate_slug(bulleted_paragraph)
+    bullet_character = bulleted_paragraph.match(/^ *([\*-])/)[1] # bullet can be '-' or '*'
+    id_prefix = "#{bullet_character} {:#{slug} .anchor-list} #{generate_anchor_list_link(slug)}"
+    bulleted_paragraph.sub!(/#{Regexp.quote(bullet_character)}/, id_prefix)
+  end
+  # finds “numbered” list items that start with number (1.)
+  # adds anchor only
+  content.gsub!(/^ *\d+\. .*?(?:\n\n|\z)/m) do |numbered_paragraph|
+    slug = generate_slug(numbered_paragraph)
+    id_prefix = "1. {:#{slug} .anchor-list .anchor-numbered}"
+    numbered_paragraph.sub!(/\d+\./, id_prefix)
+  end
+end
+
+## Run automatically on all documents
+Jekyll::Hooks.register :documents, :pre_render do |post|
+  ## Don't process documents if YAML headers say: "auto_id: false"
+  unless post.data["auto_id"] == false
+    auto_anchor(post.content)
+  end
+end
+
+module TextFilter
+  # This is a custom filter used in backlinks.html to 
+  # add anchor links to each backlink snippet
+  def link_to_anchor(text, url)
+    slug = generate_slug(text)
+    id_prefix = generate_anchor_list_link("#{url}#{slug}", "backlink-link")
+    text.sub!(/(?:-|\*|\d+\.)/, id_prefix) # this targets both “bulleted” and “numbered” list items
+    text
+  end
+end
+
+Liquid::Template.register_filter(TextFilter)

--- a/_plugins/bidirectional_links_generator.rb
+++ b/_plugins/bidirectional_links_generator.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+# This file is based on code from https://github.com/maximevaillancourt/digital-garden-jekyll-template
+# Generators run after Jekyll has made an inventory of the existing content, and before the site is generated.
+class BidirectionalLinksGenerator < Jekyll::Generator
+    def generate(site)
+  
+      all_notes = site.collections['topics'].docs
+      all_posts = site.posts.docs
+  
+      all_pages = all_notes + all_posts
+      pages_with_link_syntax = all_pages.select { |page| page.content.match(/\[\[.*?\]\]/) }
+  
+      # Convert all Wiki/Roam-style double-bracket link syntax to plain HTML
+      # anchor tag elements (<a>) with "internal-link" CSS class
+      pages_with_link_syntax.each do |current_page|
+        all_pages.each do |page_potentially_linked_to|
+          page_title_regexp_pattern = Regexp.escape(
+            File.basename(
+              page_potentially_linked_to.basename,
+              File.extname(page_potentially_linked_to.basename)
+            )
+          ).gsub('\_', '[ _]').gsub('\-', '[ -]').capitalize
+  
+          title_from_data = title_from_data_escaped = page_potentially_linked_to.data['title']
+          if title_from_data
+            title_from_data_escaped = Regexp.escape(title_from_data)
+          end
+          pr_from_data = page_potentially_linked_to.data['pr'].to_s
+          is_code = page_potentially_linked_to.data['code']
+
+          new_href = "#{site.baseurl}#{page_potentially_linked_to.url}"
+          title_anchor_tag = internal(new_href, title_from_data, is_code)
+          pr_anchor_tag = internal(new_href,"##{pr_from_data} #{title_from_data}")
+
+          # This block is used as replacement logic when an extra github link
+          # is supported next to the double-bracket link syntax
+          # e.g [[topic]](github-link-with-src-at-time-of-writing)
+          anchor_tag = proc {
+            title = "#$1"
+            if is_code
+              title = "<code>#{title}</code>"
+            end
+            anchor_tag = "<a class='internal-link' href='#{new_href}'>#{title}</a>"
+            github_anchor_tag = "<a href='#$2'><i class='fa fa-github'></i></a>"
+            # when exists, render github link as a github icon anchor 
+            "#{anchor_tag}#{$2 ? github_anchor_tag : ''}"
+          }
+
+          optional_github_link = %r{(?:\(([^)]+)\))?}
+          # Replace double-bracketed links that use the format "PR#pr_number" with pr_number & title 
+          #[[PR#27050]] => [#27050 Don't download witnesses for assumed-valid blocks when running in prune mode](/27050) 
+          current_page.content.gsub!(
+            /\[\[PR##{pr_from_data}\]\]/i,
+            pr_anchor_tag
+          )
+
+          # Replace double-bracketed links that use topic's title/filename with the given label
+          # with title: [[Branch and Bound (BnB)|this is a link to bnb]] => [this is a link to bnb](/topics/bnb)
+          # with filename: [[bnb|this is a link to bnb]] => [this is a link to bnb](/topics/bnb)
+          current_page.content.gsub!(
+            /\[\[(?:#{page_title_regexp_pattern}|#{title_from_data_escaped})\|(.+?)(?=\])\]\]#{optional_github_link}/i,
+            &anchor_tag
+          )
+
+          # Replace double-bracketed links that use topic's title
+          # [[coin selection]] => [coin selection](/topics/coin-selection)
+          # [[Coin selection]] => [Coin selection](/topics/coin-selection)
+          current_page.content.gsub!(
+            /\[\[(#{title_from_data_escaped})\]\]#{optional_github_link}/i,
+            &anchor_tag
+          )
+          # Replace double-bracketed links that use topic's filename with topic's title
+          # [[bnb]] => [Branch and Bound (BnB)](/topics/bnb)
+          current_page.content.gsub!(
+            /\[\[(#{page_title_regexp_pattern})\]\]/i,
+            title_anchor_tag
+          )
+        end
+  
+        # At this point, all remaining double-bracket-wrapped words are
+        # pointing to non-existing pages, so let's turn them into disabled
+        # links by greying them out and changing the cursor
+        #
+        # @TODO: disabled for now as this creates problem with actual usage of [[]], e.g `[[nodiscard]]`
+        # current_page.content = current_page.content.gsub(
+        #   /\[\[([^\]]+)\]\]/i, # match on the remaining double-bracket links
+        #   <<~HTML.delete("\n") # replace with this HTML (\\1 is what was inside the brackets)
+        #     <span title='There is no page that matches this link.' class='invalid-link'>
+        #       <span class='invalid-link-brackets'>[[</span>
+        #       \\1
+        #       <span class='invalid-link-brackets'>]]</span></span>
+        #   HTML
+        # )
+      end
+  
+      # Identify page backlinks and add them to each page
+      all_pages.each do |current_page|
+        # Nodes: Jekyll
+        # Create a hash to store documents and their surrounding snippets that link to the current page
+        pages_linking_to_current_page = []
+        current_page_href = "href='#{current_page.url}'"
+
+        # Iterate over pages that have double-bracket to find links to the current page
+        pages_with_link_syntax.each do |page_potentially_linking_to|
+          # Check if the current page is linked to in the potential linking page's content
+          if page_potentially_linking_to.content.include?(current_page_href)
+            # Find the paragraph snippets that link to the current page
+            paragraph_snippets = get_matching_text_blocks(page_potentially_linking_to.content, current_page_href)
+            # Add the document and its snippets to the hash
+            pages_linking_to_current_page << {"doc" => page_potentially_linking_to, "snippets" => paragraph_snippets}
+          end
+        end
+  
+        # Edges: Jekyll
+        current_page.data['backlinks'] = pages_linking_to_current_page
+
+      end
+    end
+  
+    def page_id_from_page(page)
+      page.data['title'].bytes.join
+    end
+
+    def internal(href, title, is_code=false)
+      if is_code
+        # encapsulate title with code
+        title = "<code>#{title}</code>"
+      end
+      "<a class='internal-link' href='#{href}'>#{title}</a>"
+    end
+
+    def get_matching_text_blocks(text, url)
+      # This is called only when we know that a match exists
+      # The logic here assumes that:
+      # - paragraphs have headers
+      # - each block of text (paragraph) is seperated by an empty line 
+
+      # Split the text into paragraphs
+      paragraphs = text.split(/\n\n+/)
+      # Find all the headers in the text
+      headers = text.scan(/^#+\s+(.*)$/).flatten
+
+      # Create an array of hashes containing the paragraph text and the associated header
+      current_header = 0
+      matching_paragraphs = []
+
+      # Iterate over all paragraphs to find those that match the given url
+      paragraphs.each do |p|
+        # If the current paragraph contains the URL, add it to the matching paragraphs
+        if p.include?(url)
+          matching_paragraphs << {"paragraph"=> p, "header"=> headers[current_header]}
+        end
+
+        # update to the next header when parse through it
+        if p.sub(/^#+\s*/, "") == headers[(current_header + 1) % headers.length()]
+          current_header += 1
+          # There is no need to parse after the Meeting Log section, 
+          # there are no double-bracket links there
+          if headers[current_header] == "Meeting Log"
+            break
+          end
+        end
+      end
+    
+      # Return the matching paragraphs
+      matching_paragraphs
+    end
+    
+    
+  end
+  

--- a/_plugins/hook-add-last-modified-date.rb
+++ b/_plugins/hook-add-last-modified-date.rb
@@ -1,0 +1,10 @@
+Jekyll::Hooks.register :topics, :pre_render do |topic|
+  # Generate information about the last modified date for each topic's page
+
+  # get the current topic last modified time
+  modification_time = File.mtime( topic.path )
+  
+  # inject modification_time in topic's data.
+  topic.data['last-modified-date'] = modification_time
+  
+  end

--- a/_plugins/mark_external_links.rb
+++ b/_plugins/mark_external_links.rb
@@ -1,0 +1,56 @@
+# This file is based on code from https://github.com/riboseinc/jekyll-external-links
+
+require 'nokogiri'
+require 'uri'
+
+# Given hostname and content, updates any found <a> elements as follows:
+#
+# - Adds `rel` attribute
+# - Adds css class for external link icon
+#
+# Only processes external links where `href` starts with "http"
+# and target host does not start with given site hostname.
+def process_content(site_hostname, content, marker_css, link_selector)
+  content = Nokogiri::HTML(content)
+  content.css(link_selector).each do |a|
+    next unless a.get_attribute('href') =~ /\Ahttp/i
+    next if a.get_attribute('href') =~ /\Ahttp(s)?:\/\/#{site_hostname}\//i
+    next if a.inner_html.include? "icon-ext"
+    next if a.inner_html.include? "fa" # another icon is part of the link, e.g fa-github
+    next if a.inner_html.include? a.get_attribute('href') # plain links
+    a.set_attribute('rel', 'external')
+    a.set_attribute('class', marker_css)
+  end
+  return content.to_s
+end
+
+def mark_links_in_page_or_document(page_or_document)
+  site_hostname = URI(page_or_document.site.config['url']).host
+
+  # The link is marked as external by:
+  # (1) setting the rel attribute to external and
+  # (2) appending specified marker css class.
+  marker_css = "icon-ext"
+
+  # Determines which links to mark. E.g., usually we don’t want to mark navigational links.
+  link_selector = 'a:not(.internal-link)'
+
+  # Do not process assets or other non-HTML files
+  unless (page_or_document.respond_to?(:asset_file?) and
+      page_or_document.asset_file?) or
+      page_or_document.output_ext != ".html"
+    page_or_document.output = process_content(
+      site_hostname,
+      page_or_document.output,
+      marker_css,
+      link_selector)
+  end
+end
+
+Jekyll::Hooks.register :documents, :post_render do |doc|
+  mark_links_in_page_or_document(doc)
+end
+
+Jekyll::Hooks.register :pages, :post_render do |page|
+  mark_links_in_page_or_document(page)
+end

--- a/_posts/2021-04-28-#17331.md
+++ b/_posts/2021-04-28-#17331.md
@@ -13,11 +13,10 @@ commit: 4ac1add
 ## Notes
 
 - Wallets maintain their balance as a pool of Unspent Transaction Outputs
-  (UTXOs). An
-  [OutputGroup](https://github.com/bitcoin-core-review-club/bitcoin/blob/4ac1adda9914d845aaea5804af4801ffec53c701/src/wallet/coinselection.h#L72)
+  (UTXOs). An [[OutputGroup]](https://github.com/bitcoin-core-review-club/bitcoin/blob/4ac1adda9914d845aaea5804af4801ffec53c701/src/wallet/coinselection.h#L72)
   collects all UTXOs that were sent to the same public key.
 
-- _Coin selection_ refers to the process of picking UTXOs from the wallet's UTXO
+- [[Coin selection]] refers to the process of picking UTXOs from the wallet's UTXO
   pool to fund a transaction.
 
 - Beyond the primary goal of funding a transaction, the secondary goals of coin
@@ -79,7 +78,7 @@ commit: 4ac1add
 - When a UTXO is selected as an input, the size of the transaction is increased,
   which in turn increases the necessary fees to maintain the targeted feerate.
   We can preempt the cost added by the input by considering each UTXO at its
-  _effective value_, its value reduced by the UTXO's input cost at the given
+  [[effective value]], its value reduced by the UTXO's input cost at the given
   feerate.
 
 - Bitcoin Core currently uses two different solvers:
@@ -105,14 +104,14 @@ commit: 4ac1add
       algorithm is not guaranteed to find a solution even when there are
       sufficient funds since an _exact match_ may not exist.
 
-- Using _effective values_ in coin selection means that we can freely add and
+- Using [[effective value]]s in [[coin selection]] means that we can freely add and
   remove inputs until we have have raised enough funds to pay for the
   transaction's fixed costs: the payment amounts, the transaction header and the
   output data. Whatever final input set we settle for, the increased transaction
   size and input costs have already been accounted for.
 
 - [PR #17331](https://github.com/bitcoin/bitcoin/pull/17331) implements the use
-  of _effective values_ across all different coin selection strategies. Prior,
+  of [[effective value]]s across all different [[coin selection]] strategies. Prior,
   it was only used for the BnB selection where it facilitated the search to be
   effectively performed. Introducing _effective values_ into the knapsack solver
   means it no longer works on a moving target, and thus only needs to be run
@@ -147,7 +146,7 @@ commit: 4ac1add
    and
    [`discard_feerate`](https://github.com/bitcoin-core-review-club/bitcoin/blob/4ac1adda9914d845aaea5804af4801ffec53c701/src/wallet/wallet.h#L69)?
 
-6. Why are the `OutputGroup`s calculated separately for
+6. Why are the [[OutputGroup]]s calculated separately for
    [BnB](https://github.com/bitcoin-core-review-club/bitcoin/blob/4ac1adda9914d845aaea5804af4801ffec53c701/src/wallet/wallet.cpp#L2415)
    and
    [knapsack](https://github.com/bitcoin-core-review-club/bitcoin/blob/4ac1adda9914d845aaea5804af4801ffec53c701/src/wallet/wallet.cpp#L2420)?

--- a/_posts/2021-05-05-#17526.md
+++ b/_posts/2021-05-05-#17526.md
@@ -12,7 +12,7 @@ commit: fac99dc
 
 ## Notes
 
-- **Coin selection** refers to the process of selecting UTXOs (or "coins") from
+- [[Coin selection]] refers to the process of selecting  UTXOs (or "coins") from
   a wallet's available UTXO pool to fund a transaction. Generally, the goal is
   to pick coins that will minimize fees for the user (now and in the long run),
   help the transaction reliably confirm in a timely manner, and not leak
@@ -22,20 +22,20 @@ commit: fac99dc
   strategies. We covered coin selection in a previous review club,
   [#17331](/17331).
 
-- [PR #17526](https://github.com/bitcoin/bitcoin/pull/17526) implements Single
-  Random Draw (SRD) as an additional fallback coin selection strategy. SRD is
+- [PR #17526](https://github.com/bitcoin/bitcoin/pull/17526) implements [[Single Random Draw (SRD)]] 
+  as an additional fallback [[coin selection]] strategy. SRD is
   fairly straightforward: it randomly picks `OutputGroup`s from a pool of
   eligible UTXOs until the total amount is sufficient to cover the payment and
   fees. Any extra funds are put in a change output.
 
-- This means that, with this PR, our coin selection will have three different
+- This means that, with this PR, our [[coin selection]] will have three different
   solvers: Branch and Bound (BnB), Knapsack, and Single Random Draw (SRD). Note
   that some randomness is used in coin selection, so we won't always come up
   with the same solution.
 
 - The overall strategy within
   [SelectCoins()](https://github.com/bitcoin-core-review-club/bitcoin/blob/4ac1adda9914d845aaea5804af4801ffec53c701/src/wallet/wallet.cpp#L2424)
-  (including PR #17331, on which PR #17526 is built):
+  (including [[PR#17331]], on which PR #17526 is built):
 
   - Coins manually selected by the user using `CoinControl` are added first.
 
@@ -80,8 +80,7 @@ commit: fac99dc
     Solution C: picked using SRD. Produces a change output, pays 99 satoshis in
     fees, and only uses confirmed UTXOs, each with 1 confirmation.
 
-5. What are
-   [OutputGroups](https://github.com/bitcoin-core-review-club/bitcoin/blob/4ac1adda/src/wallet/coinselection.h#L72)?
+5. What are [[OutputGroup]]s?
    Why does SRD pick from output groups rather than from UTXOs?
 
 6. What does calling `GroupOutputs()` with `positive_only=true` do (Hint: you
@@ -91,7 +90,7 @@ commit: fac99dc
 7. What are some ways a deterministic coin selection algorithm might leak
    information about the wallet's UTXO pool? Why do we
    [shuffle](https://github.com/bitcoin/bitcoin/blob/2b45cf0b/src/wallet/wallet.cpp#L2503)
-   `vCoins` before creating `OutputGroup`s?
+   `vCoins` before creating [[OutputGroup]]s?
 
 8. Bonus: We've listed some qualitative (e.g. presence of a change output) and
    quantitative (e.g. number of inputs used) ways to compare coin selection

--- a/_posts/2021-09-08-#22009.md
+++ b/_posts/2021-09-08-#22009.md
@@ -12,7 +12,7 @@ commit: 32748da0f4
 
 ## Notes
 
-* [**Coin Selection**](https://bitcoinops.org/en/topics/coin-selection/) refers to the process of
+* [[Coin Selection]] refers to the process of
   picking UTXOs (or coins) from the wallet's UTXO pool to fund a transaction. It is a complex
   problem that involves minimizing short term and long term fees, working with non-guaranteed finality
   of payments, and avoiding privacy leaks. We have covered coin selection in previous review clubs:

--- a/_posts/2022-10-19-#25515.md
+++ b/_posts/2022-10-19-#25515.md
@@ -14,8 +14,8 @@ commit: f98a4e8d89
 
 - [PR 25515](https://github.com/bitcoin/bitcoin/pull/25515) is a refactoring
   change that allows unit-testing of the
-  [`PeerManager`](https://github.com/bitcoin/bitcoin/blob/a52ff619a45c760f657413cbd40e1e2226068541/src/net_processing.h#L41)
-  class, by making `CConnman` mockable. `CConnman` is made mockable by defining
+  [[PeerManager]](https://github.com/bitcoin/bitcoin/blob/a52ff619a45c760f657413cbd40e1e2226068541/src/net_processing.h#L41)
+  class, by making [[CConnman]] mockable. `CConnman` is made mockable by defining
   an abstract interface class, `ConnectionsInterface`, that `CConnman` then
   inherits from.
 

--- a/_posts/2022-11-23-#26152.md
+++ b/_posts/2022-11-23-#26152.md
@@ -13,7 +13,7 @@ commit: 898ad9d590
 ## Notes
 
 - The wallet *funds* a transaction by selecting inputs to cover its payment amount(s) and the fee
-  at the user's target feerate. This process is known as **coin selection**, which we have discussed in
+  at the user's target feerate. This process is known as [[coin selection]], which we have discussed in
 previous review clubs [#22009](/22009), [#17526](/17526) and [#17331](/17331).
 
     - Notably, each candidate coin is considered using an "effective value," introduced in

--- a/_topics/bnb.md
+++ b/_topics/bnb.md
@@ -1,0 +1,19 @@
+---
+layout: topic
+title: Branch and Bound (BnB)
+---
+
+## Notes
+
+- How it works:
+    - Deterministically searches the complete combination space to find an input set that will avoid the creation of a change output.
+    - It performs a depth-first search on a binary tree where each branch represents the inclusion or exclusion of a UTXO, exploring inclusion branches first, and backtracking whenever a subtree cannot yield a solution.
+    - It returns the first discovered input set that is an exact match for the funding requirement of the transaction. The qualifier “exact match” here refers here to an input set that overshoots the `nTargetValue` by less than the cost of a change output.
+    - The BnB algorithm is not guaranteed to find a solution even when there are sufficient funds since an exact match may not exist.
+
+<!-- uncomment to add
+## History
+-->
+<!-- uncomment to add
+## Resources
+-->

--- a/_topics/cconnman.md
+++ b/_topics/cconnman.md
@@ -1,0 +1,17 @@
+---
+layout: topic
+title: CConnman
+code: True
+---
+
+## Notes
+
+- **CConnman** is used to manage connections(dealing with low level stuff; sending/receiving bytes, keeping statistics, eviction logic, addresses of peers, etc.) and maintain statistics on each node connected, as well as network totals. 
+
+## History
+
+- Introduced with [#8085 - p2p: Begin encapsulation](https://github.com/bitcoin/bitcoin/pull/8085)
+
+<!-- uncomment to add
+## Resources
+-->

--- a/_topics/coin-selection.md
+++ b/_topics/coin-selection.md
@@ -1,0 +1,44 @@
+---
+layout: topic
+title: Coin selection
+---
+
+## Notes
+
+- Coin selection refers to the process of picking UTXOs from the wallet’s UTXO pool to fund a transaction. Ideally, we want to minimize the number of coins we spend at any one time.
+
+- Since v23.0, Bitcoin Core runs Knapsack, [[Branch and Bound (BnB)]] and [[Single Random Draw (SRD)]] solvers in parallel and then choose among the three resulting input set candidates the one that scores best according to the [[waste metric]], which was previously already used to pick the best Branch and Bound solution.
+
+- Beyond the primary goal of funding a transaction, the secondary goals of coin selection are:
+
+    - Minimizing short term and long term fees
+        - We pay fees based on the transaction fee, and more coins means bigger sizes and thus more fees.
+        - We have to balance two needs: we want to pay the smallest fee now to get a timely confirmation, but we have to keep in mind that all of the wallet’s UTXOs will need to be spent at some point.
+        - We shouldn’t over-optimize locally at the detriment of large future costs. E.g. always using largest-first selection minimizes the current cost, but grinds the wallet’s UTXO pool to dust.
+
+    - Maintaining financial privacy
+        - Every time we “aggregate” coins together, we connect the histories of the two outpoints to one owner, degrading the privacy of the system.
+        - There are a number of heuristics that tracking companies employ to cluster payments and addresses. For example, using inputs with the same output script in two transactions indicates that the two transactions involved the same party.
+        - Similarly, it is usually assumed that all inputs of a transaction were controlled by the same entity. Sometimes the privacy and economic considerations are opposed.
+
+    - Help the transaction reliably confirm in a timely manner
+        - Using unconfirmed inputs can make transactions unreliable. Unconfirmed transactions received from another wallet may time out or be replaced, making those funds disappear. 
+        - Even using self-sent unconfirmed funds may delay the new transaction if the parent transaction has an extensive ancestry, is extraordinarily large, or used a lower feerate than targeted for the child transaction.
+
+- We’re also incentivized to try to find coins so that the input is about the same as the output so we can skip making a new change output.
+
+    - Why is it good to have no change output?
+        - Because it uses less fees(also not creating a change output saves cost now, and then also saves the future cost of spending that UTXO at a later time), reduces the overall UTXO in the system, does not put any funds into flight in a change output (a change output is an additional unconfirmed UTXO we have to track, until the tx confirms). 
+        - Breaks the change heuristic. A bunch of the chainalysis techniques revolve around guessing which output is the change returning excess funds from the input selection to the sender. When guessed correctly, this can be used to cluster future transactions with this one to build a wallet profile. By not returning any funds to the sender's wallet, there are no future transactions directly related to this transaction (unless addresses are reused)
+
+- Notably, each candidate coin is considered using an [[effective value]], introduced in [[PR#17331]]. This deducts the cost to spend this input at the target feerate from its `nValue`.
+
+<!-- uncomment to add
+## History
+-->
+
+## Resources
+
+- <https://bitcoinops.org/en/topics/coin-selection/>
+- [What are the trade-offs between the different algorithms for deciding which UTXOs to spend?](https://bitcoin.stackexchange.com/questions/32145/what-are-the-trade-offs-between-the-different-algorithms-for-deciding-which-utxo)
+- [Goals of Coin Selection and Overview of the Coin Selection algorithms](https://bitcoin.stackexchange.com/a/32445)

--- a/_topics/effective-value.md
+++ b/_topics/effective-value.md
@@ -1,0 +1,14 @@
+---
+layout: topic
+title: Effective value
+---
+
+<!-- uncomment to add
+## Notes
+-->
+<!-- uncomment to add
+## History
+-->
+<!-- uncomment to add
+## Resources
+-->

--- a/_topics/outputgroup.md
+++ b/_topics/outputgroup.md
@@ -1,0 +1,17 @@
+---
+layout: topic
+title: OutputGroup
+code: True
+---
+
+## Notes
+
+- OutputGroups are UTXOs with the same `scriptPubKey`.
+
+## History
+
+- [#17458 - Refactor OutputGroup effective value calculations and filtering to occur within the struct](https://github.com/bitcoin/bitcoin/pull/17458)
+
+<!-- uncomment to add
+## Resources
+-->

--- a/_topics/peermanager.md
+++ b/_topics/peermanager.md
@@ -1,0 +1,22 @@
+---
+layout: topic
+title: PeerManager
+code: True
+---
+
+<!-- uncomment to add
+## Notes
+-->
+## History
+
+- `NetEventsInterface` was introduced with [#10756 - swap out signals for an interface class](https://github.com/bitcoin/bitcoin/pull/10756) to replace signals.
+
+- net_processing logic started moving into `PeerManager`(then `PeerLogicValidation`) with [#19704 - net processing: move ProcessMessage() to PeerLogicValidation](https://github.com/bitcoin/bitcoin/pull/19704) and [#19791 - net processing: Move Misbehaving() to PeerManager](https://github.com/bitcoin/bitcoin/pull/19791).
+
+- Rename from `PeerLogicValidation` to `PeerManager` as part of [#19791 - net processing: Move Misbehaving() to PeerManager](https://github.com/bitcoin/bitcoin/pull/19791)
+
+- Split into interface and implementation (`PeerManagerImpl`) with [#20811 - move net_processing implementation details out of header](https://github.com/bitcoin/bitcoin/pull/20811)
+
+<!-- uncomment to add
+## Resources
+-->

--- a/_topics/srd.md
+++ b/_topics/srd.md
@@ -1,0 +1,14 @@
+---
+layout: topic
+title: Single Random Draw (SRD)
+---
+
+<!-- uncomment to add
+## Notes
+-->
+<!-- uncomment to add
+## History
+-->
+<!-- uncomment to add
+## Resources
+-->

--- a/_topics/waste-metric.md
+++ b/_topics/waste-metric.md
@@ -1,0 +1,17 @@
+---
+layout: topic
+title: Waste metric
+---
+
+## Notes
+
+- Initially introduced as part of [[bnb]]
+
+- It was generalized to be used for all [[coin selection]] solvers with [[PR#22009]].
+
+<!-- uncomment to add
+## History
+-->
+## Resources
+
+- [What does "Waste Metric" mean in the context of Coin Selection?](https://bitcoin.stackexchange.com/questions/113622/what-does-waste-metric-mean-in-the-context-of-coin-selection)

--- a/assets/css/all.sass
+++ b/assets/css/all.sass
@@ -50,6 +50,7 @@ body
   --log-color: #808080
   --target-color: #dddddd
   --meeting-index-color: #606060
+  --backlinks-box-color: #f5f5f5
 
 // Dark
 #color-mode:checked ~ .site-container
@@ -62,6 +63,7 @@ body
   --log-color: #080808
   --target-color: #3a3939
   --meeting-index-color: #8c5e5e
+  --backlinks-box-color: #282727
 
 a
   color: var(--link-color)
@@ -167,3 +169,29 @@ a
   font-size: 50%
   display: flex
   align-items: flex-end
+
+.invalid-link
+  color: #444444
+  cursor: help
+  background: #fafafa
+  padding: 0 0.1em
+
+.invalid-link-brackets
+  color: #ccc
+  cursor: help
+
+.backlink-box
+  position: relative
+  font-size: 0.9em
+  background: var(--backlinks-box-color)
+  padding: 2px
+  border-radius: 4px
+  padding-top: 0.6em
+  padding-left: 3em
+
+.backlink-header
+  position: absolute
+  top: 0.2em
+  left: 0.7em
+  font-size: 0.85em
+  color: #828282

--- a/assets/css/all.sass
+++ b/assets/css/all.sass
@@ -180,6 +180,16 @@ a
   color: #ccc
   cursor: help
 
+.icon-ext
+  &:after
+    position: relative
+    top: -0.5em
+    font-size: 0.7em
+    content: "↗"
+    color: #aaaaaa
+    display: inline-block
+    text-decoration: none
+
 .backlink-box
   position: relative
   font-size: 0.9em

--- a/assets/css/all.sass
+++ b/assets/css/all.sass
@@ -205,3 +205,34 @@ a
   left: 0.7em
   font-size: 0.85em
   color: #828282
+
+@keyframes highlightfade
+    from
+        background: var(--target-color)
+    to
+        background: transparent
+
+.anchor-list
+  list-style: none
+  &:target
+    background: transparent
+    animation-name: highlightfade
+    animation-duration: 7s
+
+.anchor-numbered
+  list-style: decimal
+
+.anchor-list-link
+  color: var(--text-color)
+  margin-left: -14px
+  padding-right: 3px
+  font-size: 0.45em
+  display: inline-block
+  position: relative
+  top: -0.4em /* position the dot vertically in the middle of the container element */
+  text-decoration: none
+
+.backlink-link
+  @extend .anchor-list-link
+  font-size: 0.7em
+  top: -0.25em

--- a/topics.html
+++ b/topics.html
@@ -1,0 +1,22 @@
+---
+layout: default
+title: Topics
+permalink: /topics/
+---
+
+<div class="Home">
+  <h2 class="Home-posts-title">Topics</h2>
+
+    <table style="padding-left: 1.5em;">
+        {% for topic in site.topics %}
+            <tr class="Home-posts-post">
+                <td class="Home-posts-post-arrow">
+                    &raquo;
+                </td>
+                <td>
+                    <a class="Home-posts-post-title" href="{{ topic.url }}">{{ topic.title }}</a>
+                </td>
+            </tr>
+        {% endfor %}
+    </table>
+</div>


### PR DESCRIPTION
### Overview

I see the PR Review Club as one of the best resources for context gathering. And this is mostly due to the notes that the individual hosts are putting together each week (_meeting logs also, but I'll get back to these in a future idea_). Through my experience participating and exploring past meetings I have also recognized the limitation described in #621. I have been thinking of ways to address those limitations, as well as some incremental changes that can potentially bring this resource closer to its full potential.

#### Current limitations

- Repeating topics. As also pointed out in #621, there are a lot of re-defintions of topics. Except of the additional burden that this adds to the host, building on top of existing definitions could potentially result to a better and more future-proof resource.
- Topics get outdated. Last year's inner workings of coin selection might not be the same as today. Having different definitions might be confusing.
- Underutilized knowledge base. While this accumulation of notes is gradually creating a comprehensive knowledge base, the current navigation options are limited to filtering by PR component (p2p, mempool, rpc, etc.)

#### Solution

This PR is an attempt to solve these limitations by introducing "Topics" as a type of glossary for review club meetings. Additionally it introduces a way to automatically create bidirectional links between pages (pr pages, topic pages) which provides another way to navigate through the pages, essentially transforming this knowledge base to a knowledge graph.

This fixes #621 and also paves the way for #429 , as relatedness can easily calculated based on the topics mentioned in each page.

### Implementation

The **first commit** introduces the bidirectional linking logic. This is based on the [digital-garden-jekyll-template](https://github.com/maximevaillancourt/digital-garden-jekyll-template) and the back-links UI is based on how [Roam Research](https://roamresearch.com/) displays back-links in each page.


![comparison](https://user-images.githubusercontent.com/18506343/227444458-ee4c4302-62a3-4540-85cb-fb3993eb39c2.jpg)
_(above img: snippets from the back-links of the `coin selection` page. Left: [my own notes in Roam](https://roamresearch.com/#/app/kouloumos/page/R4DjGnK4T), Right: review club's `/topics/coin-selection` page after this PR)_

This works with the support for double-bracket link syntax `[[]]` which creates a bidirectional link from the current page to the linking page. You can see the logic (with comments) in `bidirectional_links_generator.rb`, and I have also included **linking examples in the second commit** alongside a rake command for new topics page generation.

With the introduction of topics and the internal linking of pages it makes sense to have a way to differentiate between internal and external links. This is done in the **third commit** by adding a subtle symbol next to external links. ~There, I also took the opportunity to automatically modify all external links to open to a new tab (if I am the only one bother by that, it can easily be reverted).~

(**removed for now**)~The _ commit is just an interesting addition of a graph view, again taken from the [digital-garden-jekyll-template](https://github.com/maximevaillancourt/digital-garden-jekyll-template), it shows another way that pages can be explored when this kind of bidirectional relationships are defined. At its current form is not ideal, ~that's why is not accessible from anywhere else but the `/graph` link~. I can drop this last commit, I just wanted to highlight another way that pages can be explored when this kind of bidirectional relationships are defined. Also, looking at the graph, it's easier to conceptualize how this can be used to calculated relatedness of review club meetings for #429 .~
<details><summary>removed graph view</summary>
<img src="https://user-images.githubusercontent.com/18506343/227459266-95122c16-6db5-48bf-bc4a-96516e301f45.png" alt="graph" width="500">
</details>



The **fourth commit** adds anchors to each list item. This is an idea based on [bitcoinops](https://github.com/bitcoinops/bitcoinops.github.io), that allows each text block to be directly referenceable from within backlinks.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/18506343/227460105-8a7fbc0f-fae0-4d98-9252-64db5e315962.gif)



### TODO

- Apply this linking to past PR pages in order to create better references between them and also connect them with the topics that they are dealing with. My second commit is just an example of how this could be done (manually).

### Personal Note

I agree with https://github.com/bitcoin-core-review-club/website/issues/621#issuecomment-1420570493 regarding the fragmentation of information. I've been doing [a bit of thinking](https://www.kouloumos.com/context-gathering/) about the current fragmentation of information and how we could find a way to close the gap and enable better context gathering for current and future contributors. This is definitely not dealing with the fragmentation but I don't believe it enhances it. I see this as a way to improve the current knowledge base while also adding the notion of internal linking that in the future can potentially evolve to cross-site linking and bring the different overlapping knowledge bases a bit closer.
