### PR TITLE
print a warning when there are no labels from github

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -177,7 +177,7 @@ def create_post_file!(filename, response, date, host)
   title = parse_title(response['title'])
   components = parse_valid_components(response['labels'])
   if components.empty?
-    puts "No labels from Github, you will need to add one manually from #{COMPONENTS}"
+    puts "No label assigned to the PR yet; you will need to add one manually from #{COMPONENTS}"
   end
 
   puts "GitHub PR title:  \"#{response['title']}\""

--- a/Rakefile
+++ b/Rakefile
@@ -176,6 +176,9 @@ end
 def create_post_file!(filename, response, date, host)
   title = parse_title(response['title'])
   components = parse_valid_components(response['labels'])
+  if components.empty?
+    puts "No labels from Github, you will need to add one manually from #{COMPONENTS}"
+  end
 
   puts "GitHub PR title:  \"#{response['title']}\""
   puts "Parsed PR title:  #{title}"


### PR DESCRIPTION
probably not the most elegant way to do this, so happy for suggestions on how to improve it!

without this, the post will fail to build when running `make preview`, but it fails with a really obtuse error:

```
Configuration file: /home/josibake/website/_config.yml
            Source: /home/josibake/website
       Destination: /home/josibake/website/_site
 Incremental build: enabled
      Generating... 
       Jekyll Feed: Generating feed for posts
  Liquid Exception: Could not locate the included file 'ERROR_92_MISSING_TOPIC_CATEGORY' in any of ["/home/josibake/website/_includes"]. Ensure it exists in one of those directories and, if it is a symlink, does not point outside your site source. in meetings-components.html
```

took me longer than id like to admit to troubleshoot it.

at least the warning will point people in the right direction.. even better would be a command line arg for passing a label