### PR TITLE
Add RSS and Twitter favicons

### DIFF
--- a/_data/social-media.yml
+++ b/_data/social-media.yml
@@ -1,0 +1,9 @@
+atom:
+  href: 'feed.xml'
+  title: 'Atom Feed'
+  fa-icon: 'fa-rss'
+
+twitter:
+  href: 'https://twitter.com/bitcoincoreprs'
+  title: 'Twitter'
+  fa-icon: 'fa-twitter-square'

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,8 @@
 <header>
   <div class="logo">
+    <div class="social-media-links" style="display: inline; float: right;">
+      {% include social-media-links.html %}
+    </div>
     <a href="{{ site.github.url }}/" class="logo">{{ site.data.settings.title }}</a>
   </div>
   <nav>

--- a/_includes/social-media-links.html
+++ b/_includes/social-media-links.html
@@ -1,0 +1,9 @@
+{% if site.data.social-media %}
+<div id="social-media">
+    {% assign sm = site.data.social-media %}
+    {% for entry in sm %}
+        {% assign key = entry | first %}
+        <a href="{{ sm[key].href }}" title="{{ sm[key].title }}"><i class="fa {{ sm[key].fa-icon }}" style="color: #000000;"=></i></a>
+    {% endfor %}
+</div>
+{% endif %}

--- a/assets/css/all.sass
+++ b/assets/css/all.sass
@@ -162,3 +162,8 @@ a
 .log-msg
   padding-left: 0px
   white-space: pre-wrap
+
+.social-media-links
+  font-size: 50%
+  display: flex
+  align-items: flex-end

--- a/index.md
+++ b/index.md
@@ -27,7 +27,8 @@ on GitHub.
 
 <span class="question">How do I take part?</span> Just show up on IRC! See
 [Attending your first PR Review Club](/your-first-meeting/) for more tips
-on how to participate.
+on how to participate. To stay up to date on newly announced review clubs,
+you can follow us on <a href="{{ site.data.social-media.twitter.href }}">Twitter</a> or via the <a href="{{ site.data.social-media.atom.href }}">Atom feed</a>.
 
 <span class="question">Who runs this?</span> &nbsp;Upcoming meetings are
 scheduled by {{ site.coordinator }}.


### PR DESCRIPTION
Partially addresses #625, implementing jnewbery's [suggestion](https://github.com/bitcoin-core-review-club/website/issues/625#issuecomment-1481089733) to include favicons for our Twitter and Atom feed on the site header.

My jekyll and frontend skills are minimal, so I'm very open to suggestions on implementing this in a cleaner way, although I think it's fairly maintainable as is. To edit the icons, one can just update `_data/social-media.yml`.

<img width="1092" alt="image" src="https://user-images.githubusercontent.com/69010457/227569543-2bdb4f86-ff39-4c62-a392-25be3c7b0d1c.png">
