### PR TITLE
Remove empty test_rake_posts_new test

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ All site configurations are either contained in `_config.yml` or `_data/settings
 
 To run all tests: `rake test` or just `rake`
 
-To run one test file: `rake TEST=test/test_rake_posts_new`
+To run one test file: `rake TEST=test/test_site_content`
 
 To run an individual test in a test file:
-`rake TEST=test/test_rake_posts_new TESTOPTS=--name=test_rake_posts_new`
+`rake TEST=test/test_site_content TESTOPTS=--name=test_site_displays_no_empty_nicks`
 
 Before running tests for the first time, you may need to run `bundle update`.
 

--- a/test/test_rake_posts_new.rb
+++ b/test/test_rake_posts_new.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require_relative 'test_helper'
-
-class TestRakePostsNew < Minitest::Test
-  def test_rake_posts_new
-    assert true
-  end
-end


### PR DESCRIPTION
This test just asserts true and exits. I think it was originally intended to test the `rake posts:new` function, but was never implemented (see #45)