### PR TITLE
n27255: ambiguate between wrapper d: and property d

### DIFF
--- a/_posts/2023-04-05-#27255.md
+++ b/_posts/2023-04-05-#27255.md
@@ -42,9 +42,9 @@ Putting it all together, this PR adds support for Tapscript in Miniscript in Bit
 
 1. This PR [adds](https://github.com/bitcoin-core-review-club/bitcoin/commit/c0ba8ebbf6369b37b645165bb5cd638fc7eee67f) a `multi_a` fragment for Tapscript. How is this different than the existing `multi` fragment? Does it have the same properties as `multi`? Why?
 
-1. In Miniscript, we have type modifiers, which guarantee additional properties for an expression. [866284d](https://github.com/bitcoin-core-review-club/bitcoin/commit/866284d007993551f681809d9e48175a3b0fe0c1) makes "**d**" have the "**u**" property under Tapscript.
-	* What are the "**d**" and "**u**" type modifiers?
-	* Why is it that we can make **d** have the **u** property here? Why not in non-Tapscript Miniscript?
+1. In Miniscript, we have type modifiers, which guarantee additional properties for an expression. [866284d](https://github.com/bitcoin-core-review-club/bitcoin/commit/866284d007993551f681809d9e48175a3b0fe0c1) makes the wrapper "**d:**" have the "**u**" property under Tapscript.
+	* What is the "**d:**" wrapper and the "**u**" type modifier?
+	* Why is it that we can make **d:** have the **u** property here? Why not in non-Tapscript Miniscript?
 
 1. This PR adds some logic for statically ensuring no spending path exceeds the stack size at execution time:
 	* Why does this matter for Tapscript?


### PR DESCRIPTION
MiniScript uses `d` for the "dissatisfiable" _property_, and `d:X` for the `DUP IF [X] ENDIF` _wrapper_.  I don't think the question meant to refer to the "dissatisfiable" property, but to the wrapper?

cc @josibake 