### PR TITLE
Fix XML parsing error in Atom feed URL

### DIFF
--- a/_posts/2023-04-19-#27039.md
+++ b/_posts/2023-04-19-#27039.md
@@ -211,7 +211,7 @@ commit: 93c70287a
 17:44 <sipa> I'm not sure if progress is saved during the first block index rebuilding phase, but if past-me says so, it's probably true.
 17:44 <pinheadmz> past-you is so smart
 17:45 <pinheadmz> and is reindex-chainstate then just skipping right to that ssecond step ?
-17:45 <sipa> Exactly. -reindex-chainstate is exactly equivalent to rm -rf ~/.bitcoin/chainstate
+17:45 <sipa> Exactly. -reindex-chainstate is exactly equivalent to rm -rf ~/.bitcoin/chainstate
 17:45 <LarryRuane> that second phase takes much longer in practice, BTW ... actually @sipa aren't there now 3 phases? first block headers (takes only a couple of minutes on most systems), then the two you mentioned?
 17:45 <lightlike> sure - but what if it's aborted midway through the first part
 17:45 <LarryRuane> and actually, block headers are now downloeaded twice

--- a/_posts/2023-04-19-#27039.md
+++ b/_posts/2023-04-19-#27039.md
@@ -211,7 +211,7 @@ commit: 93c70287a
 17:44 <sipa> I'm not sure if progress is saved during the first block index rebuilding phase, but if past-me says so, it's probably true.
 17:44 <pinheadmz> past-you is so smart
 17:45 <pinheadmz> and is reindex-chainstate then just skipping right to that ssecond step ?
-17:45 <sipa> Exactly. -reindex-chainstate is exactly equivalent to rm -rf ~/.bitcoin/chainstate
+17:45 <sipa> Exactly. `-reindex-chainstate` is exactly equivalent to `rm -rf ~/.bitcoin/chainstate`
 17:45 <LarryRuane> that second phase takes much longer in practice, BTW ... actually @sipa aren't there now 3 phases? first block headers (takes only a couple of minutes on most systems), then the two you mentioned?
 17:45 <lightlike> sure - but what if it's aborted midway through the first part
 17:45 <LarryRuane> and actually, block headers are now downloeaded twice


### PR DESCRIPTION
by removing special characters added in the meeting log last week. These don't appear to be displayed in the HTML page at https://bitcoincore.reviews/27039#l-158.

The URL https://bitcoincore.reviews/feed.xml currently errors with:

```
XML Parsing Error: not well-formed
Location: https://bitcoincore.reviews/feed.xml
Line Number 253, Column 412:
&lt;table class=&quot;log-line&quot; id=&quot;l-158&quot;&gt;&lt;tr class=&quot;log-row&quot;&gt;&lt;td class=&quot;log-lineno&quot;&gt;&lt;a href=&quot;#l-158&quot;&gt;158&lt;/a&gt;&lt;/td&gt;&lt;td class=&quot;log-time&quot;&gt;17:45 &lt;/td&gt;&lt;td&gt;&lt;span class=&quot;log-nick&quot; style=&quot;color:cadetblue&quot;&gt;&amp;lt;sipa&amp;gt;&lt;/span&gt;&lt;span class=&quot;log-msg&quot;&gt; Exactly. -reindex-chainstate is exactly equivalent to rm -rf ~/.bitcoin/chainstate&lt;/span&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;
```
