### PR TITLE
rename getprioritisationmap to getprioritisedtransactions to match PR

### DIFF
--- a/_posts/2023-05-03-#27501.md
+++ b/_posts/2023-05-03-#27501.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 date: 2023-05-03
-title: "Add getprioritisationmap, delete a mapDeltas entry when delta==0"
+title: "Add getprioritisedtransactions, delete a mapDeltas entry when delta==0"
 pr: 27501
 authors: [glozow]
 components: ["rpc/rest/zmq", "mempool"]
@@ -65,8 +65,8 @@ set to 0, it removes the entry from `mapDeltas` entirely.
 17:00 <kevkevin> hey
 17:00 <glozow> Hi everyone! Welcome to PR Review Club. Feel free to say hi so we know you're here. Any first-timers?
 17:00 <abubakarsadiq> hi
-17:01 <glozow> We're looking at #27501, add getprioritisationmap, delete a mapDeltas entry when delta==0 today
-17:01 <glozow> Notes and questions in the usual place: add getprioritisationmap, delete a mapDeltas entry when delta==0
+17:01 <glozow> We're looking at #27501, add getprioritisedtransactions, delete a mapDeltas entry when delta==0 today
+17:01 <glozow> Notes and questions in the usual place: add getprioritisedtransactions, delete a mapDeltas entry when delta==0
 17:01 <LarryRuane> hi
 17:01 <glozow> oops bad copypaste. https://bitcoincore.reviews/27501
 17:02 <glozow> Did y'all get a chance to review the PR and/or look at the notes? How about a y/n
@@ -245,7 +245,7 @@ set to 0, it removes the entry from `mapDeltas` entirely.
 17:55 <LarryRuane> txid?
 17:56 <kevkevin> glozow: the same way we call prioritisetransaction
 17:56 <glozow> then you have to remember that it's in your mapDeltas?
-17:57 <kevkevin> well I guess the other way would be to call getprioritisationmap but we already do that with this PR haha
+17:57 <kevkevin> well I guess the other way would be to call getprioritisedtransactions but we already do that with this PR haha
 17:57 <glozow> jnewbery suggested to me offline that perhaps we could implicitly interpret `prioritisetransaction(txid, 0, delta=0)` as "clear prioritisation." I think that could be an extra simplification.
 17:58 <kevkevin> glozow: ya I think that would be better than a whole new rpc
 17:58 <sebastianvanstaa> glozow yes that would make sense


### PR DESCRIPTION
I don't know if we want to merge this PR because it would be changing history, but the name of the RPC was changed so this makes the review club document match the PR (and the code).