### PR TITLE
announce v25rc-testing

### DIFF
--- a/_posts/2023-05-24-v25-rc-testing.md
+++ b/_posts/2023-05-24-v25-rc-testing.md
@@ -1,0 +1,32 @@
+---
+layout: pr
+date: 2023-05-24
+title: "Testing Bitcoin Core 25.0 Release Candidates"
+components: ["tests"]
+host: abubakarsadiq
+status: upcoming
+commit:
+---
+
+## Notes
+
+- Major versions of Bitcoin Core are released every 6-8 months. See the [Life
+  Cycle documentation](https://bitcoincore.org/en/lifecycle/) for full details.
+- When all of the PRs for a release have been merged, _Release Candidate 1_
+  (rc1) is tagged. The rc is then tested. If any issues are found, fixes are
+  merged into the branch and a new rc is tagged. This continues until no major
+  issues are found in an rc, and that rc is then considered to be the final
+  release version.
+- To ensure that users don't experience issues with the new software, it's
+  essential that the rcs are thoroughly tested. This special review club
+  meeting is for people who want to help with that vital review process.
+
+
+<!-- TODO: Add testing guide-->
+
+<!-- TODO: After meeting, uncomment and add meeting log between the irc tags
+## Meeting Log
+
+{% irc %}
+{% endirc %}
+-->


### PR DESCRIPTION
@ismaelsadeeq I'll make the announcement already, and then you can add the link to the testing guide and some notes (if relevant) when finished with that?

See e.g. https://bitcoincore.reviews/v24-rc-testing and https://bitcoincore.reviews/v23-rc-testing