### PR TITLE
june 21 2023 - announce n27748 (was n26697)

### DIFF
--- a/_posts/2023-06-21-#27748.md
+++ b/_posts/2023-06-21-#27748.md
@@ -1,10 +1,10 @@
 ---
 layout: pr
 date: 2023-06-21
-title: "logging: use bitset for categories"
-pr: 26697
+title: "util: generalize accounting of system-allocated memory in pool resource"
+pr: 27748
 authors: [LarryRuane]
-components: ["utils/log/libs"]
+components: ["utxo db and indexes"]
 host: larryruane
 status: upcoming
 commit:


### PR DESCRIPTION
We just announced n26697 (#696), but we already covered that PR back on [Jan 18, 2023](https://github.com/bitcoin-core-review-club/website/blob/master/_posts/2023-01-18-%2326697.md). It has changed substantially since then, so I considered reviewing it in its current form but decided against it, so we'll go with 27748 instead. Sorry about the confusion. I'll get the notes and questions done in the next few days.