### PR TITLE
n28122: dont create 2 irc blocks

### DIFF
--- a/_posts/2023-08-02-#28122.md
+++ b/_posts/2023-08-02-#28122.md
@@ -203,11 +203,8 @@ Before reviewing the PR, it is _strongly_ recommended that you read the [BIP](ht
 18:00 <josie> cool, we'll stop here and be back tomorrow! thanks for attending and really hope to see you all tomorrow! 
 18:00 <josie> #endmeeting
 
-{% endirc %}
-
 ### Meeting 2
 
-{% irc %}
 17:00 <josie> #startmeeting
 17:00 <josie> hi, and welcome back to round 2!
 17:00 <abubakarsadiq> hi


### PR DESCRIPTION
fixes #710, which we should do asap

The plugin runs per irc block so it restarts the log line number for the second meeting log block.
This puts everything under 1 block, means the numbering continues. Tbh I like this better as it feels more like a continuation of the same meeting on a different day.

This is how we did it for other review club PRs with 2 meetings: https://bitcoincore.reviews/16981#l-216

I'll open a separate PR for fixing the rakefile, where we can talk about whether this is the best solution for multiple meeting logs.