### PR TITLE
add announcement for v28 rc testing

### DIFF
--- a/_posts/2024-09-11-v28-rc-testing.md
+++ b/_posts/2024-09-11-v28-rc-testing.md
@@ -1,0 +1,35 @@
+---
+layout: pr
+date: 2024-09-11
+title: "Testing Bitcoin Core 28.0 Release Candidates"
+authors: [rkrux]
+components: ["tests"]
+host: rkrux
+status: upcoming
+commit:
+---
+
+## Notes
+
+- Major versions of Bitcoin Core are released every 6-8 months. See the [Life
+  Cycle documentation](https://bitcoincore.org/en/lifecycle/) for full details.
+
+- When all of the PRs for a release have been merged, _Release Candidate 1_
+  (rc1) is tagged. The rc is then tested. If any issues are found, fixes are
+  merged into the branch and a new rc is tagged. This continues until no major
+  issues are found in an rc, and that rc is then considered to be the final
+  release version.
+
+- To ensure that users don't experience issues with the new software, it's
+  essential that the rcs are thoroughly tested. This special review club
+  meeting is for people who want to help with that vital review process.
+
+- This [Bitcoin Core Release Candidate Testing Guide](https://github.com/bitcoin-core/bitcoin-devwiki/wiki/28.0-Release-Candidate-Testing-Guide) provides guidance for testing the release candidate.
+
+- Feel free to read the [Release Notes](https://github.com/bitcoin-core/bitcoin-devwiki/wiki/28.0-Release-Notes-Draft)
+  and bring ideas of other things you'd like to test!
+
+<!-- ## Meeting Log -->
+
+<!-- {% irc %} -->
+<!-- {% endirc %} -->


### PR DESCRIPTION
The testing guide is still wip, but we can announce now to schedule the meeting.