### PR TITLE
contrib: bugfix: allow empty user.ghtoken

### DIFF
--- a/contrib/new_post.py
+++ b/contrib/new_post.py
@@ -59,7 +59,7 @@ def git_config_get(option, default=None):
     Get named configuration option from git repository.
     '''
     try:
-        return subprocess.run(['git','config','--get',option], capture_output=True).stdout.rstrip().decode('utf-8')
+        return subprocess.check_output(['git','config','--get',option], encoding='utf-8').rstrip()
     except subprocess.CalledProcessError:
         return default
 


### PR DESCRIPTION
subprocess.run() does not throw a CalledProcessError when the process exits with a non-zero exit code, unless `check=True` is set. This means that when the `option` key is not found, an empty string is returned instead, causing a wrong ghtoken to be used for the `Authorization` header.

This leads to:
```
% ./contrib/new_post.py 30239 <author> 2024-11-06
Github returned error HTTP Error 401: Unauthorized
```

Fix this and simplify the code by using the convenience function `subprocess.check_output()` instead.

Addresses https://github.com/bitcoin-core-review-club/website/pull/764#issuecomment-2432690897