### PR TITLE
active link to StackExchange article and make it non-footnote

### DIFF
--- a/_posts/2025-03-05-#31405.md
+++ b/_posts/2025-03-05-#31405.md
@@ -12,7 +12,7 @@ commit: 4ba2e480ffa0b77113953bee4ff5c9349e277e7e
 
 ## Notes
 
-- The [`BlockManager::m_block_index`](https://github.com/bitcoin/bitcoin/blob/3c1f72a36700271c7c1293383549c3be29f28edb/src/node/blockstorage.h#L277) is a map which is used to keep track of which block headers exist, how they interconnect, and where on disk the block data (if any) is stored [^1]. Generally speaking, it is updated whenever a new valid header with sufficient Proof-of-Work (PoW) is received. It contains entries for blocks in the current most-PoW chain, alternative chains, and even invalid blocks.
+- The [`BlockManager::m_block_index`](https://github.com/bitcoin/bitcoin/blob/3c1f72a36700271c7c1293383549c3be29f28edb/src/node/blockstorage.h#L277) is a map which is used to keep track of which block headers exist, how they interconnect, and where on disk the block data (if any) is stored ([StackExchange](https://bitcoin.stackexchange.com/a/51026/129640)). Generally speaking, it is updated whenever a new valid header with sufficient Proof-of-Work (PoW) is received. It contains entries for blocks in the current most-PoW chain, alternative chains, and even invalid blocks.
 
 - The `CBlockIndex` objects in this map can be considered the nodes in a tree shaped structure with the genesis block at its root. By definition, each block can only point to a [single predecessor](https://github.com/bitcoin/bitcoin/blob/3c1f72a36700271c7c1293383549c3be29f28edb/src/chain.h#L147), but multiple blocks can point to the same predecessor. Of course, in a single chain, this tree is pruned so that each block will never have more than one block pointing to it. The entire tree structure is kept to enable efficiently handling chain reorgs.
 
@@ -55,7 +55,3 @@ commit: 4ba2e480ffa0b77113953bee4ff5c9349e277e7e
 {% irc %}
 {% endirc %}
 -->
-
-## Footnotes
-
-[^1]: https://bitcoin.stackexchange.com/a/51026/129640 


### PR DESCRIPTION
Footnote 1 (the only footnote) is the URL to a StackExchange article, but it's not an active link. It would be nice to make it an active link, but I thought I'd suggest it not be a footnote (no review club documents have footnotes up until now) but to put the link right inline with the text; that seems more convenient for the reader. 

But if you'd rather keep it as a footnote, I'd be glad to change this PR (but have it be an active link), or feel free to make any changes yourself (no need to ask me, as time is limited).