### PR TITLE
change time, remove explicit cadence, reword some things

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,10 +12,10 @@ sass:
 author:            "Bitcoin Core PR Review Club contributors"
 coordinator:       "[glozow](https://github.com/glozow) and [stickies-v](https://github.com/stickies-v)"
 coordinator_irc:   "glozow or stickies-v"
-description:       "A monthly review club for Bitcoin Core PRs"
-meeting_day:       "Wednesday and Thursday"
+description:       "A review club for Bitcoin Core PRs"
+meeting_day:       "Wednesday"
 meeting_location:  'the #bitcoin-core-pr-reviews IRC channel on <a href="https://web.libera.chat/?channel=#bitcoin-core-pr-reviews">libera.chat</a>'
-meeting_time:      "17:00 UTC"
+meeting_time:      "16:00 UTC"
 title:             "Bitcoin Core PR Review Club"
 twitter:
   card:            summary

--- a/_layouts/pr.html
+++ b/_layouts/pr.html
@@ -56,10 +56,8 @@ layout: default
     {%- endunless -%}
     </p>
 
-    {% if page.status == "past" %}
-      {% if page.commit %}
+    {% if page.commit %}
       <p><em>The PR branch HEAD was <a href="https://github.com/bitcoin-core-review-club/bitcoin/tree/pr{{ page.id | remove_first: "/#" }}/">{{ page.commit }}</a> at the time of this review club meeting.</em><p>
-      {%- endif -%}
     {%- endif -%}
 
     <p>

--- a/hosting.md
+++ b/hosting.md
@@ -7,19 +7,11 @@ title: Hosting a Review Club Meeting
 
 ## How to Choose a PR
 
-- The purpose of PR Review Club is to help new contributors learn about the
-  Bitcoin Core codebase and the process of contributing to the project. Select a PR
-  that is likely to be instructive or interesting. Don't select a PR just because
-  you want it to be merged soon! You may even select a PR that is already merged.
-
-- The PR can be complex, but keep in mind that attendees may be at a variety of
-  different experience levels. Some attendees have only just cloned the Bitcoin
-  Core repo for the first time, and some have been contributing for months or
-  years. If you choose a complex PR, try to provide notes that would help a
-  beginner get up to speed.
-
-- It's fine to discuss a PR that you opened yourself. After all, you probably
-  know more about it than anyone else!
+- The purpose of PR Review Club is to encourage and enable people to participate
+  in PR review, not just to review things. The best kind of PR is one that is
+interesting but not too ambitious - remember that some people might only have a
+few days to prepare. If you choose a complex PR, try to provide notes that would
+help a beginner get up to speed.
 
 - The appropriate amount of code change to discuss depends on the complexity of
   the code. It might be fine to discuss 10-20 lines of code if the change is
@@ -31,6 +23,16 @@ title: Hosting a Review Club Meeting
   run additional meetings during the week to accommodate higher interest on more
   complex PRs. If you feel additional time is appropriate, don't hesitate to
   propose something!
+
+- It's fine to discuss a PR that you opened yourself. After all, you probably
+  know more about it than anyone else! On the other hand, a host who is not the
+author may provide a good perspective.
+
+- Already-merged PRs are fair game.
+
+- The PR doesn't necessarily need to be to the Bitcoin Core repository. For
+  example, bitcoin-inquisition, libsecp256k1, and repos for Bitcoin Core-adjacent
+things are certainly relevant.
 
 ## Before the Meeting
 
@@ -61,11 +63,9 @@ title: Hosting a Review Club Meeting
   - Potential bugs reviewers might want to look out for.
   - Fun C++ things.
 
-- You may want to think about how you want to split the discussion across two
-  meetings. Here are some ideas:
-
-  - Conceptual and approach, then implementation.
-  - The first n commits of the PR, then the last n commits.
+- You may want to think about how you want to structure the discussion. For
+  example, you may want to discuss conceptual, approach, then implementation.
+  Larger PRs can also be split by commit.
 
 - If you refer to yourself in the notes, use third person narrative
   (e.g. your name or GitHub profile) rather than first person ("I").

--- a/index.md
+++ b/index.md
@@ -2,26 +2,29 @@
 layout: default
 title: home
 ---
-### A monthly review club for Bitcoin Core PRs
+### A review club for Bitcoin Core PRs
 
-<span class="question">What is this?</span> &nbsp;A monthly club for reviewing
-Bitcoin Core PRs in {{ site.meeting_location }}. Meetings take place on the **first 
-{{ site.meeting_day }} of the month, at {{ site.meeting_time }}**.
+<span class="question">What is this?</span> &nbsp;A club for reviewing
+Bitcoin Core PRs in {{ site.meeting_location }}. Meetings take place on **{{ site.meeting_day }}, at {{ site.meeting_time }}**.
 
-<span class="question">What's it for?</span> &nbsp;To help newer contributors
-learn about the Bitcoin Core codebase and review process. The review club is *not* primarily
-intended to help open PRs get merged.
+<span class="question">What's it for?</span> &nbsp;To help all contributors
+learn about the Bitcoin Core codebase and participate in the review process. The
+review club is meant to be **beginner-friendly**, and is *not* primarily intended to
+help open PRs get merged.
 
 <span class="question">Who should take part?</span> &nbsp;Anyone who wants to
 learn about contributing to Bitcoin Core. All are welcome to come and ask
 questions!
 
 <span class="question">What's the benefit for participants?</span>
-&nbsp;Reviewing and testing PRs is the best way to start contributing to Bitcoin
-Core, but it's difficult to know where to start. There are hundreds of open PRs,
-many require a lot of contextual knowledge, and contributors and reviewers often
-use unfamiliar terminology. The review club will give you the tools and
-knowledge you need in order to take part in the [Bitcoin Core review
+&nbsp;Reviewing PRs is hard, and much more fun with friends. Authors and working
+groups can use this venue to answer questions, document discussions in public,
+and encourage more people to join.  For newcomers, reviewing and testing PRs is
+the best way to start contributing to Bitcoin Core, but it's difficult to know
+where to start. There are hundreds of open PRs, many require a lot of contextual
+knowledge, and contributors and reviewers often use unfamiliar terminology. The
+review club will give you the tools and knowledge you need in order to take part
+in the [Bitcoin Core review
 process](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#peer-review)
 on GitHub.
 


### PR DESCRIPTION
(1) Change meeting time to 16 UTC to match the #bitcoin-core-dev meeting. In the future, if the meeting time changes, I would propose that we mirror it.

(2) Cadence: try to go back to weekly. Remove the "wednesday and thursday" thing as that didn't really pan out.

(3) Slight "rebranding": instead of being focused on beginners, the review club + irc channel is a place for people to learn and work in public and be open to new joiners. In particular, it's fine for people to try to use this meeting to make progress on PRs, and this can be a way for working groups to "work in public" and create a way for new people to join them.

The format will be the same: notes to provide an on-ramp for beginners, questions to kickstart the discussion and guide review. I think the primary difference is the PR selection - they should still be limited in scope, but we can focus on *interesting*