### PR TITLE
Add Docker support and instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.gitignore
+.DS_Store
+_site
+.sass-cache
+.jekyll-cache
+.jekyll-metadata
+vendor
+.bundle
+Dockerfile
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ruby:2.6.6-slim
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    libcurl4-openssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY Gemfile* ./
+
+RUN gem install bundler -v 2.4.22
+RUN bundle install
+
+EXPOSE 4000

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ preview:
 	## Don't do a full rebuild (to save time), but always rebuild index.html and meetings pages
 	rm _site/index.html || true
 	rm -rf _site/meetings* || true
-	bundle exec jekyll serve --future --drafts --unpublished --incremental
+	bundle exec jekyll serve --host 0.0.0.0 --future --drafts --unpublished --incremental
 
 build:
 	bundle exec jekyll clean

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ Simple Jekyll site for hosting the Bitcoin Core PR Review club at https://bitcoi
 
 ## Development
 
+### Using Docker (recommended)
+
+You'll need [Docker](https://docs.docker.com/get-docker/) and [Docker
+Compose](https://docs.docker.com/compose/install/) installed.
+
+* Clone the repository and go into the directory
+* Run `docker compose up preview` to start the development server with
+  live reload
+* Go to http://localhost:4000
+
+### Traditional Setup
+
 You'll need [Ruby and Jekyll](https://jekyllrb.com/docs/installation/) to run
 the site locally. Ruby 2.6 is recommended. Once they are set up:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+  preview:
+    build: .
+    ports:
+      - "4000:4000"
+    volumes:
+      - .:/app
+    command: make preview


### PR DESCRIPTION
Adding Docker support makes it much easier for people to preview the website when making changes.

From the updated README:

```
You'll need [Docker](https://docs.docker.com/get-docker/) and [Docker
Compose](https://docs.docker.com/compose/install/) installed.

* Clone the repository and go into the directory
* Run `docker compose up` to start the development server with live
  reload
* Go to http://localhost:4000

```

(Note: to test this PR, it might be wise to add `--build` to the command, in case the Dockerfile changes: `docker compose up --build`)