### PR TITLE
Fix XML feed by removing illegal characters and updating sanitization logic

### DIFF
--- a/_posts/2024-09-11-v28-rc-testing.md
+++ b/_posts/2024-09-11-v28-rc-testing.md
@@ -72,7 +72,7 @@ commit:
 17:20 <Murch[m]> Sorry, I don’t think my node is accessible from outside our network
 17:20 <glozow> mine too 😅 
 17:20 <Murch[m]> Happy to send some testnet4 coins to someone, though
-17:21 <Murch[m]> I …um… tested the twenty minute exception a few times to mine some
+17:21 <Murch[m]> I …um… tested the twenty minute exception a few times to mine some
 17:22 <glozow> haha
 17:22 <glozow> should we all share our bestblockhash?
 17:23 <rkrux55> yes
@@ -128,7 +128,7 @@ commit:
 17:46 <glozow> hahaha. i mean i guess we can build the parent+children before broadcasting but kind of a pain
 17:46 <Murch[m]> Anyone else need testnet4 corn, while we are at it?
 17:46 <Guest61> Yeah I don’t know how to do this either. I am real beginner starting from zero
-17:47 <Murch[m]> I iterated on my approach, I’m now using sendall with my address as the unspecified amount, and a fixed amount for you, and using as an option {minconf: 0}
+17:47 <Murch[m]> I iterated on my approach, I’m now using sendall with my address as the unspecified amount, and a fixed amount for you, and using as an option {minconf: 0}
 17:47 <rkrux55> Murch: yes please tb1qw8kwpwtvs2y7e3aj4rpu3m498lnedv9txkhw7h
 17:47 <rkrux55> murch:
 17:49 <Murch[m]> rkrux55: 0108c479401cf81c5715dac49557d7acaa7c5327d173ec583606a924bb258915

--- a/hosting.md
+++ b/hosting.md
@@ -198,6 +198,7 @@ _This process is done by the review club maintainers_
       | sed -n '/#startmeeting/h;//!H;$!d;x;//p' \
       | sed '/#endmeeting/q' \
       | sed '/[⇐→]/d' \
+      | LC_ALL=C tr -dc '\011\012\015\040-\176\200-\377' \
       | cut -c 13-17,22- \
       > sanitized_log.txt
     ```


### PR DESCRIPTION
The #771 logs added GS (Group Separator, 0x1D) and SI (Shift In, 0x0F) characters, likely because of text formatting in a rich-text IRC client. These are not valid XML characters, so they broke our XML feed (feed.xml)

Fix this by removing the illegal characters and update the instructions in `hosting.md` to specify the allowed range of characters as tab (\011), newline (\012), carriage return (\015), ASCII printable characters (\040-\176), and extended
ASCII/UTF-8 continuation bytes (\200-\377).

Testing the new `LC_ALL=C tr -dc '\011\012\015\040-\176\200-\377'` command on `feed.xml` did indeed only remove the illegal characters from #771, so I think this is a safe addition to our sanitization logic.

Fixes #803 