### PR TITLE
style: automatically set dark mode, and fix invisible icons

### DIFF
--- a/_includes/social-media-links.html
+++ b/_includes/social-media-links.html
@@ -3,7 +3,7 @@
     {% assign sm = site.data.social-media %}
     {% for entry in sm %}
         {% assign key = entry | first %}
-        <a href="{{ sm[key].href }}" title="{{ sm[key].title }}"><i class="fa {{ sm[key].fa-icon }}" style="color: #000000;"=></i></a>
+        <a href="{{ sm[key].href }}" title="{{ sm[key].title }}"><i class="fa {{ sm[key].fa-icon }}"></i></a>
     {% endfor %}
 </div>
 {% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,9 +5,6 @@
 
 <body>
 
-  <input id="color-mode" type="checkbox" name="color-mode" onclick='save()'>
-  <label id="color-mode-switch" for="color-mode">💡</label>
-
   <div class="site-container">
     <div class="page-content">
       {% include header.html %}
@@ -17,15 +14,5 @@
   <div>
 
 </body>
-
-<script>
-  function save() {
-    const dark = document.getElementById('color-mode').checked;
-    window.localStorage.setItem('dark', String(dark));
-  }
-
-  const dark = window.localStorage.getItem('dark') === "true";
-  document.getElementById('color-mode').checked = dark;
-</script>
 
 </html>

--- a/assets/css/all.sass
+++ b/assets/css/all.sass
@@ -31,16 +31,8 @@ body
   height: 100%
   min-height: 100%
 
-#color-mode
-  display: none
-
-#color-mode-switch
-  user-select: none
-  right: 0
-  position: absolute
-
 // Light (default)
-#color-mode:not(:checked) ~ .site-container
+.site-container
   --bg-color: white
   --text-color: black
   --link-color: #0000f0
@@ -51,17 +43,18 @@ body
   --target-color: #dddddd
   --meeting-index-color: #606060
 
-// Dark
-#color-mode:checked ~ .site-container
-  --bg-color: black
-  --text-color: white
-  --link-color: #58a6ff
-  --link-visited-color: #824bb7
-  --code-bg-color: #565656
-  --log-bg-color: #565656
-  --log-color: #080808
-  --target-color: #3a3939
-  --meeting-index-color: #8c5e5e
+// Dark mode using media query
+@media (prefers-color-scheme: dark)
+  .site-container
+    --bg-color: black
+    --text-color: white
+    --link-color: #58a6ff
+    --link-visited-color: #824bb7
+    --code-bg-color: #565656
+    --log-bg-color: #565656
+    --log-color: #080808
+    --target-color: #3a3939
+    --meeting-index-color: #8c5e5e
 
 a
   color: var(--link-color)

--- a/assets/css/all.sass
+++ b/assets/css/all.sass
@@ -42,6 +42,7 @@ body
   --log-color: #808080
   --target-color: #dddddd
   --meeting-index-color: #606060
+  --icon-color: black
 
 // Dark mode using media query
 @media (prefers-color-scheme: dark)
@@ -55,6 +56,7 @@ body
     --log-color: #080808
     --target-color: #3a3939
     --meeting-index-color: #8c5e5e
+    --icon-color: white
 
 a
   color: var(--link-color)
@@ -160,3 +162,6 @@ a
   font-size: 50%
   display: flex
   align-items: flex-end
+
+.fa
+  color: var(--icon-color)


### PR DESCRIPTION
According to https://caniuse.com/?search=prefers-color-scheme, >96% of users have a browser that supports prefers-color-scheme.

Simplify UX, clean up code by following the browser/system dark mode settings and remove the manual toggle.

Also fixes #678 by rendering icons as white in dark mode.

Tested on Chrome and Firefox.


Alternative to #809