### PR TITLE
Fix commit links in 33300 notes

### DIFF
--- a/_posts/2025-10-08-#33300.md
+++ b/_posts/2025-10-08-#33300.md
@@ -69,9 +69,9 @@ commit: ed813c48f826d083becf93c741b483774c850c86
 
 5. Look at `create_block` in the harness. How many transactions do the generated blocks contain, and where do they come from? What compact block scenarios might be missed with only a few transactions in a block?
 
-6. In commit [ecba804](https://github.com/bitcoin/bitcoin/pull/33300/commits/ecba804b0d034bbb6e61510cd2161b2ae449ac8d) `FinalizeHeader` is moved to `util.h` so it can be used by any fuzz test. What is the purpose of this function and why doesn’t it slow down the fuzzer?
+6. In commit [254e13c](https://github.com/bitcoin/bitcoin/commit/254e13cd442a7a0fbb32ed6d9d20202d7eacfff9) `FinalizeHeader` is moved to `util.h` so it can be used by any fuzz test. What is the purpose of this function and why doesn’t it slow down the fuzzer?
 
-7. Commit [e2f9214](https://github.com/bitcoin/bitcoin/pull/33300/commits/e2f921458913bcbbe74115cdb2174b0ab31784f2) sorts `m_dirty_blockindex` by block hash instead of pointer address. What non-determinism does this fix?  The author [notes](https://github.com/bitcoin/bitcoin/pull/33300#issuecomment-3308381089) this slows production code for no production benefit. Why can't [`EnableFuzzDeterminism()`](https://github.com/bitcoin/bitcoin/blob/acc7f2a433b131597124ba0fbbe9952c4d36a872/src/util/check.h#L34) be used here? How do you think this non-determinism should be best handled (if not the way the PR currently does)?
+7. Commit [ed813c4](https://github.com/bitcoin/bitcoin/commit/ed813c48f826d083becf93c741b483774c850c86) sorts `m_dirty_blockindex` by block hash instead of pointer address. What non-determinism does this fix?  The author [notes](https://github.com/bitcoin/bitcoin/pull/33300#issuecomment-3308381089) this slows production code for no production benefit. Why can't [`EnableFuzzDeterminism()`](https://github.com/bitcoin/bitcoin/blob/acc7f2a433b131597124ba0fbbe9952c4d36a872/src/util/check.h#L34) be used here? How do you think this non-determinism should be best handled (if not the way the PR currently does)?
 
 8. The harness adds prefilled transactions to a compact block beyond the coinbase. Walk through the index calculations for prefilling transactions at indices 1 and 3 in a 4-transaction block. Do you think this code could be simplified or cleaned up, and if so, what do you suggest?
 


### PR DESCRIPTION
Commit links did not work because of the force push. Replaced them with the new link format (that should work regardless of force pushes) and new hashes.